### PR TITLE
Use special e2e company for testing push/pull

### DIFF
--- a/panoramic/cli/cassettes/test_push_pull_e2e/test_push_pull_e2e.yaml
+++ b/panoramic/cli/cassettes/test_push_pull_e2e/test_push_pull_e2e.yaml
@@ -9,17 +9,17 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - pano-cli/1.2.0
+      - pano-cli/1.4.0
     method: GET
     uri: https://a1.panocdn.com/updates/pano-cli/versions.json
   response:
     body:
-      string: '{"minimum_supported_version": "1.0.0", "latest_version": "1.2.0"}'
+      string: '{"minimum_supported_version": "1.3.1", "latest_version": "1.3.3"}'
     headers:
       Accept-Ranges:
       - bytes
-      Cache-Control:
-      - max-age=60
+      Age:
+      - '6254'
       Connection:
       - keep-alive
       Content-Length:
@@ -27,25 +27,25 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Nov 2020 15:10:12 GMT
+      - Fri, 20 Nov 2020 09:44:31 GMT
       ETag:
-      - '"b567ca5ec4a1c3c27497963ad975f8f5"'
+      - '"27c3611f3cf23f5e138de084cc76d1b7"'
       Last-Modified:
-      - Fri, 30 Oct 2020 21:22:49 GMT
+      - Wed, 18 Nov 2020 13:00:30 GMT
       Server:
       - AmazonS3
       Via:
-      - 1.1 c37f72766931ae9c3f146ffa54018d1c.cloudfront.net (CloudFront)
+      - 1.1 4b0f0fc4315eea23426f6074a7254a8d.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - B3pnnuDXN6e_fKek6oZiA-Yt8kGueCShGaL4CmwqHe-HPAZLouoZJQ==
+      - 9Xmh_33Z8ockKZEWnJA8jknspkg2HNzZsvSK9XhEkIOPDSUvaL0SYQ==
       X-Amz-Cf-Pop:
       - IAD89-C2
       X-Cache:
-      - RefreshHit from cloudfront
+      - Hit from cloudfront
       x-amz-replication-status:
       - COMPLETED
       x-amz-version-id:
-      - 7gL4L94FhP5vViOT0_j0Ees.dSesIhqr
+      - mG5i_duZYt9G0wN9uH2LFIW2WoQ756Fc
     status:
       code: 200
       message: OK
@@ -63,7 +63,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded;charset=UTF-8
       User-Agent:
-      - pano-cli/1.2.0
+      - pano-cli/1.4.0
     method: POST
     uri: https://id.panoramichq.com/oauth2/auscsj124wDoFObOJ4x6/v1/token
   response:
@@ -76,7 +76,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 02 Nov 2020 15:10:13 GMT
+      - Fri, 20 Nov 2020 11:28:44 GMT
       Keep-Alive:
       - timeout=5, max=100
       Server:
@@ -97,17 +97,17 @@ interactions:
       - no-cache
       set-cookie:
       - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
-      - JSESSIONID=306130B5A62150DF08D7C417D8FF51BA; Path=/; Secure; HttpOnly
+      - JSESSIONID=3B8504F812AD0471FF4A6988CD1EAAAE; Path=/; Secure; HttpOnly
       x-content-type-options:
       - nosniff
       x-okta-request-id:
-      - X6AhVSBSBnq4H3Poi8K0DgAABzc
+      - X7eobGJxZFlkQaWEcVfHXwAAAQk
       x-rate-limit-limit:
       - '1200'
       x-rate-limit-remaining:
-      - '1199'
+      - '1188'
       x-rate-limit-reset:
-      - '1604329873'
+      - '1605871743'
       x-xss-protection:
       - '0'
     status:
@@ -123,9 +123,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - pano-cli/1.2.0
+      - pano-cli/1.4.0
     method: GET
-    uri: https://diesel.panoramicapi.com/api/v1/federated/virtual-data-source?company_slug=panoramic-z5y1clyi&offset=0&limit=100
+    uri: https://diesel.panoramicapi.com/api/v1/federated/virtual-data-source?company_slug=panoramic-cli-e2e-c2m6qp4u&offset=0&limit=100
   response:
     body:
       string: '{"data":[]}
@@ -139,7 +139,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Nov 2020 15:10:16 GMT
+      - Fri, 20 Nov 2020 11:28:45 GMT
       Via:
       - kong/2.0.3
       X-Amzn-Trace-Id:
@@ -147,9 +147,9 @@ interactions:
       X-Kong-Proxy-Latency:
       - '0'
       X-Kong-Upstream-Latency:
-      - '514'
+      - '38'
       x-diesel-request-id:
-      - bcbac8b8-b53e-47aa-9b48-68060e3b8a78
+      - 1b8c0c8a-558b-4d43-93e3-f66a131ec897
     status:
       code: 200
       message: OK
@@ -167,7 +167,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded;charset=UTF-8
       User-Agent:
-      - pano-cli/1.2.0
+      - pano-cli/1.4.0
     method: POST
     uri: https://id.panoramichq.com/oauth2/auscsj124wDoFObOJ4x6/v1/token
   response:
@@ -180,7 +180,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 02 Nov 2020 15:10:17 GMT
+      - Fri, 20 Nov 2020 11:28:46 GMT
       Keep-Alive:
       - timeout=5, max=100
       Server:
@@ -201,17 +201,17 @@ interactions:
       - no-cache
       set-cookie:
       - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
-      - JSESSIONID=FB27095F81D43CFEE3EB9A7DB6079B9A; Path=/; Secure; HttpOnly
+      - JSESSIONID=3972D95E353A876E06534E17C47E72F4; Path=/; Secure; HttpOnly
       x-content-type-options:
       - nosniff
       x-okta-request-id:
-      - X6AhWZH7Ucj-1fRyMM@-2gAACKs
+      - X7eobWEUmtk0zJ6olg6XWgAAAZE
       x-rate-limit-limit:
       - '1200'
       x-rate-limit-remaining:
-      - '1198'
+      - '1187'
       x-rate-limit-reset:
-      - '1604329873'
+      - '1605871743'
       x-xss-protection:
       - '0'
     status:
@@ -227,132 +227,23 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - pano-cli/1.2.0
+      - pano-cli/1.4.0
     method: GET
-    uri: https://diesel.panoramicapi.com/api/v1/federated/taxonomy/taxons?company_slug=panoramic-z5y1clyi&offset=0&limit=100
+    uri: https://diesel.panoramicapi.com/api/v1/federated/taxonomy/taxons?company_slug=panoramic-cli-e2e-c2m6qp4u&offset=0&limit=100
   response:
     body:
-      string: '{"data":[{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_type":"numeric","description":"How
-        much of the expected value has been delivered to the customer","display_name":"Delivery","field_type":"metric","group":"Custom","slug":"delivery","taxon_type":"metric"},{"calculation":null,"data_type":"text","description":null,"display_name":"Health
-        Score Date","field_type":"dimension","group":"Custom","slug":"health_score_date","taxon_type":"dimension"},{"calculation":null,"data_type":"text","description":"Name
-        of Client","display_name":"Account Name","field_type":"dimension","group":"Custom","slug":"account_name","taxon_type":"dimension"},{"calculation":null,"data_type":"text","description":null,"display_name":"Grade","field_type":"dimension","group":"Custom","slug":"grade_1","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_type":"numeric","description":"How
-        the customer feels about the platform","display_name":"Sentiment","field_type":"metric","group":"Custom","slug":"sentiment","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_type":"text","description":null,"display_format":"decimal_2","display_name":"Platform
-        - Pano Test","field_type":"dimension","group":"Custom","slug":"platform_pano_test","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_type":"numeric","description":"Ho
-        much the client is engaged with the platform","display_name":"Usage","field_type":"metric","group":"Custom","slug":"usage","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"contact_list_id","field_type":"metric","group":"CLI","slug":"hubspot|contact_list_id","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"contact_id","field_type":"metric","group":"CLI","slug":"hubspot|contact_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"added_at","field_type":"dimension","group":"CLI","slug":"hubspot|added_at","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_event_delivered_id","field_type":"dimension","group":"CLI","slug":"hubspot|email_event_delivered_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"smtp_id","field_type":"dimension","group":"CLI","slug":"hubspot|smtp_id","taxon_type":"dimension"},{"aggregation":{"type":"avg"},"aggregation_type":"avg","calculation":null,"data_type":"money","description":"Max
-        is testing","display_name":"Max''s CPA","field_type":"metric","group":"Custom","slug":"my_cpa","taxon_type":"metric"},{"calculation":null,"data_type":"text","description":"A
-        conversion is a click on the \"download\" button (traffic to a landing page),
-        so not a true conversion","display_name":"Conversion - LinkedIn","field_type":"dimension","group":"Custom","slug":"conversion_linked_in","taxon_type":"dimension"},{"calculation":null,"data_type":"text","description":"An
-        aggregated and anonymized dataset used for comparison respective to whichever
-        Dimensions (e.g. Objective, Publisher, Age, Country, etc.) have been applied
-        in the platform.","display_name":"Benchmark","field_type":"dimension","group":"Custom","slug":"benchmark","taxon_type":"dimension"},{"calculation":null,"data_type":"text","description":null,"display_format":null,"display_name":"Company
-        test field","field_type":"dimension","group":"Custom","slug":"company_test_field","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"is_deleted","field_type":"dimension","group":"CLI","slug":"hubspot|is_deleted","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_businessunity_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_businessunity_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_analytics_engineer_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_analytics_engineer_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_analytics_source_data_2","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_source_data_2","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_analytics_source_data_1","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_source_data_1","taxon_type":"dimension"},{"calculation":null,"data_source":"test_dataset","data_type":"text","description":null,"display_format":null,"display_name":"Dataset
-        test field","field_type":"metric","group":"Custom","slug":"test_dataset|dataset_test_field","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"
-        (panoramic_z5y1clyi__usage*3)+(2*panoramic_z5y1clyi__delivery)+(panoramic_z5y1clyi__sentiment*5)","data_type":"numeric","description":"Weighted
-        Score","display_name":"Total Score","field_type":"metric","group":"Custom","slug":"total_score","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"merge(?facebook_ads|campaign_name,?linkedin|campaign_group_name)","data_type":"text","description":"Campaign
-        Naming Convention (Social)","display_format":"decimal_2","display_name":"Pano
-        Campaign Name","field_type":"dimension","group":"Custom","slug":"pano_campaign_name","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"?
-        facebook_ads|actions__offsite_conversion_fb_pixel_lead_value + ?facebook_ads|actions__onsite_conversion__lead_grouped_value  +
-        ?adwords|conversions_purchase + ?linkedin|external_website_conversions + ?appnexus|total_convs
-        ","data_type":"numeric","description":null,"display_format":"decimal_0","display_name":"GH
-        Test","field_type":"metric","group":"Custom","slug":"gh_test","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"merge(?facebook_ads|adset_name,?linkedin|campaign_name)","data_type":"text","description":"Pano
-        Ad Set Name used for Parsing Naming Covention","display_format":"decimal_2","display_name":"Pano
-        Adgroup Name","field_type":"dimension","group":"Custom","slug":"pano_ad_set_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"engagement_type","field_type":"dimension","group":"CLI","slug":"hubspot|engagement_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"activity_type","field_type":"dimension","group":"CLI","slug":"hubspot|activity_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"engagement_last_updated","field_type":"dimension","group":"CLI","slug":"hubspot|engagement_last_updated","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"guid","field_type":"dimension","group":"CLI","slug":"hubspot|guid","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"portal_id","field_type":"metric","group":"CLI","slug":"hubspot|portal_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"form_name","field_type":"dimension","group":"CLI","slug":"hubspot|form_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"action","field_type":"dimension","group":"CLI","slug":"hubspot|action","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"method","field_type":"dimension","group":"CLI","slug":"hubspot|method","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"css_class","field_type":"dimension","group":"CLI","slug":"hubspot|css_class","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"to_number","field_type":"dimension","group":"CLI","slug":"hubspot|to_number","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"from_number","field_type":"dimension","group":"CLI","slug":"hubspot|from_number","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"engagement_call_status","field_type":"dimension","group":"CLI","slug":"hubspot|engagement_call_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"external_id","field_type":"dimension","group":"CLI","slug":"hubspot|external_id","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"duration_milliseconds","field_type":"metric","group":"CLI","slug":"hubspot|duration_milliseconds","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"external_account_id","field_type":"dimension","group":"CLI","slug":"hubspot|external_account_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"recording_url","field_type":"dimension","group":"CLI","slug":"hubspot|recording_url","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"disposition","field_type":"dimension","group":"CLI","slug":"hubspot|disposition","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"callee_object_type","field_type":"dimension","group":"CLI","slug":"hubspot|callee_object_type","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"callee_object_id","field_type":"metric","group":"CLI","slug":"hubspot|callee_object_id","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"transcription_id","field_type":"metric","group":"CLI","slug":"hubspot|transcription_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_email","field_type":"dimension","group":"CLI","slug":"hubspot|property_email","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"change","field_type":"dimension","group":"CLI","slug":"hubspot|change","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"change_type","field_type":"dimension","group":"CLI","slug":"hubspot|change_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"caused_by_event_id","field_type":"dimension","group":"CLI","slug":"hubspot|caused_by_event_id","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"email_subscription_id","field_type":"metric","group":"CLI","slug":"hubspot|email_subscription_id","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"parse(panoramic_z5y1clyi__pano_campaign_name
-        , ''_'', 4)","data_type":"text","description":"Parsed: Campaign Audience Type
-        from Pano Campaign Name","display_format":"decimal_2","display_name":"Campaign
-        Audience Type","field_type":"dimension","group":"Custom","slug":"campaign_audience_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"app_name","field_type":"dimension","group":"CLI","slug":"hubspot|app_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_campaign_name","field_type":"dimension","group":"CLI","slug":"hubspot|email_campaign_name","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"num_included","field_type":"metric","group":"CLI","slug":"hubspot|num_included","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"num_queued","field_type":"metric","group":"CLI","slug":"hubspot|num_queued","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"sub_type","field_type":"dimension","group":"CLI","slug":"hubspot|sub_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_campaign_type","field_type":"dimension","group":"CLI","slug":"hubspot|email_campaign_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"calendar_event_id","field_type":"dimension","group":"CLI","slug":"hubspot|calendar_event_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"event_type","field_type":"dimension","group":"CLI","slug":"hubspot|event_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"event_date","field_type":"dimension","group":"CLI","slug":"hubspot|event_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"category","field_type":"dimension","group":"CLI","slug":"hubspot|category","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"category_id","field_type":"metric","group":"CLI","slug":"hubspot|category_id","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"content_id","field_type":"metric","group":"CLI","slug":"hubspot|content_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"state","field_type":"dimension","group":"CLI","slug":"hubspot|state","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_event_click_id","field_type":"dimension","group":"CLI","slug":"hubspot|email_event_click_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"ip_address","field_type":"dimension","group":"CLI","slug":"hubspot|ip_address","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"user_agent","field_type":"dimension","group":"CLI","slug":"hubspot|user_agent","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_type":"text","description":"this
-        is sacha''s test","display_format":"decimal_2","display_name":"Sacha''s Dimension
-        Test","field_type":"dimension","group":"Custom","slug":"sacha_s_dimension_test","taxon_type":"dimension"},{"calculation":null,"data_type":"text","description":"Testing","display_format":null,"display_name":"Panoramic
-        test","field_type":"dimension","group":"Custom","slug":"panoramic_test","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"concat(panoramic_z5y1clyi__campaign_type,\"
-        \",panoramic_z5y1clyi__targeting)","data_type":"text","description":"Concat.
-        Google Search. Branded or Non-Branded Campaigns.","display_format":"decimal_2","display_name":"Campaign
-        Type","field_type":"dimension","group":"Custom","slug":"campaign_type_3","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"parse(panoramic_z5y1clyi__pano_ad_name
-        , ''_'',3)","data_type":"text","description":"Parsed: Creative Type from Pano
-        Ad Name","display_format":"decimal_2","display_name":"Creative Type","field_type":"dimension","group":"Custom","slug":"creative_type","taxon_type":"dimension"},{"aggregation":{"type":"avg"},"aggregation_type":"avg","calculation":"panoramic_z5y1clyi_v_d_s_hubspot|property_implicit_score
-        ","data_type":"numeric","description":"Average of Implicit Score","display_format":"decimal_0","display_name":"Implicit
-        Score (Avg)","field_type":"metric","group":"Custom","slug":"implicit_score_avg","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"merge(?facebook_ads|ad_name,?panoramic_z5y1clyi__google_ads_headline_concatenation,?appnexus|creative_name,?linkedin|creative_id)","data_type":"text","description":"DNU
-        Testing Ad Name Merge","display_format":"decimal_2","display_name":"DNU Ad
-        Name Merge","field_type":"dimension","group":"Custom","slug":"dnu_ad_name_merge","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"?adwords|conversions_purchase
-        + ?linkedin|external_website_conversions + ?appnexus|total_convs + ?facebook_ads|actions__offsite_conversion_fb_pixel_lead_value
-        + ?facebook_ads|actions__onsite_conversion__lead_grouped_value ","data_type":"numeric","description":"Total
-        Lead Forms Submitted on Pano Landing Page","display_format":"decimal_0","display_name":"Leads
-        (Pano LP)","field_type":"metric","group":"Custom","slug":"leads_custom","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"coalesce(panoramic_z5y1clyi__showtime_lookup_1
-        ,impressions )","data_type":"numeric","description":null,"display_format":"decimal_2","display_name":"KT
-        test DNU","field_type":"metric","group":"Custom","slug":"kt_test_dnu","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"vid","field_type":"dimension","group":"CLI","slug":"hubspot|vid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"saved_at_timestamp","field_type":"dimension","group":"CLI","slug":"hubspot|saved_at_timestamp","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"deleted_changed_timestamp","field_type":"dimension","group":"CLI","slug":"hubspot|deleted_changed_timestamp","taxon_type":"dimension"},{"aggregation":{"type":"avg"},"aggregation_type":"avg","calculation":"300*1","data_type":"money","description":"8/1/20
-        - 8/31/20 CPL (Pano LP) Goal","display_format":"usd_2","display_name":"GOAL:
-        CPL (Pano LP)","field_type":"metric","group":"Custom","slug":"cpl_goal","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"from_email","field_type":"dimension","group":"CLI","slug":"hubspot|from_email","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"from_first_name","field_type":"dimension","group":"CLI","slug":"hubspot|from_first_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"from_last_name","field_type":"dimension","group":"CLI","slug":"hubspot|from_last_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"subject","field_type":"dimension","group":"CLI","slug":"hubspot|subject","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"html","field_type":"dimension","group":"CLI","slug":"hubspot|html","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"text","field_type":"dimension","group":"CLI","slug":"hubspot|text","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"tracker_key","field_type":"dimension","group":"CLI","slug":"hubspot|tracker_key","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"message_id","field_type":"dimension","group":"CLI","slug":"hubspot|message_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"contact_list_name","field_type":"dimension","group":"CLI","slug":"hubspot|contact_list_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"deleteable","field_type":"dimension","group":"CLI","slug":"hubspot|deleteable","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"dynamic","field_type":"dimension","group":"CLI","slug":"hubspot|dynamic","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"metadata_processing","field_type":"dimension","group":"CLI","slug":"hubspot|metadata_processing","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"metadata_last_size_change_at","field_type":"dimension","group":"CLI","slug":"hubspot|metadata_last_size_change_at","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"metadata_error","field_type":"dimension","group":"CLI","slug":"hubspot|metadata_error","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"offset","field_type":"metric","group":"CLI","slug":"hubspot|offset","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_format":"decimal_0","display_name":"Size","field_type":"metric","group":"CLI","slug":"hubspot|metadata_size","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"parse(panoramic_z5y1clyi__pano_ad_set_name
-        , ''_'', 4)","data_type":"text","description":"Parsed: Ad Set Audience from
-        Pano Ad Set Name","display_format":"decimal_2","display_name":"Adgroup Audience","field_type":"dimension","group":"Custom","slug":"ad_set_audience","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"searches
-        ","data_type":"numeric","description":"Showtime Lookup","display_format":"decimal_2","display_name":"Showtime
-        Lookup","field_type":"metric","group":"Custom","slug":"showtime_lookup_1","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"?linkedin|landing_page_clicks
-        + ?adwords|clicks + ?facebook_ads|actions__link_click_value + ?appnexus|clicks
-        ","data_type":"numeric","description":"Total Clicks to Landing Page","display_format":"decimal_0","display_name":"Clicks
-        to LP","field_type":"metric","group":"Custom","slug":"clicks_to_lp","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"parse(panoramic_z5y1clyi__pano_campaign_name
-        , ''_'',  3)","data_type":"text","description":"Parsed: Campaign Audience
-        Group from Pano Naming Convention","display_format":"decimal_2","display_name":"Campaign
-        Audience Group","field_type":"dimension","group":"Custom","slug":"campaign_audience_group","taxon_type":"dimension"}]}
+      string: '{"data":[]}
 
         '
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '24902'
+      - '12'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Nov 2020 15:10:18 GMT
-      Via:
-      - kong/2.0.3
-      X-Amzn-Trace-Id:
-      - None
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '325'
-      x-diesel-request-id:
-      - 5ecf1a66-c822-428f-afec-29d3a36aaf81
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - pano-cli/1.2.0
-    method: GET
-    uri: https://diesel.panoramicapi.com/api/v1/federated/taxonomy/taxons?company_slug=panoramic-z5y1clyi&offset=100&limit=100
-  response:
-    body:
-      string: '{"data":[{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"parse(panoramic_z5y1clyi__pano_ad_name
-        , ''_'', 5)","data_type":"text","description":"Parsed: Ad Text/Copy from Pano
-        Ad Name","display_format":"decimal_2","display_name":"Ad Text/Copy","field_type":"dimension","group":"Custom","slug":"ad_text_copy","taxon_type":"dimension"},{"aggregation":{"type":"avg"},"aggregation_type":"avg","calculation":"spend
-        / panoramic_z5y1clyi__clicks_to_lp ","data_type":"money","description":"Cost
-        per Landing Page Click","display_format":"usd_2","display_name":"CPC (LP)","field_type":"metric","group":"Custom","slug":"cpc_lp","taxon_type":"metric"},{"calculation":null,"data_type":"text","description":null,"display_format":null,"display_name":"Objective","field_type":"dimension","group":"Custom","slug":"objective","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"sumiff(data_source==\"facebook_ads\",30,sumiff(data_source==\"linkedin\",25,sumiff(data_source==\"adwords\",75)))","data_type":"numeric","description":"Data
-        Source Leads (Pano LP) Goal for 8/1-8/31","display_format":"decimal_0","display_name":"GOAL:
-        Leads (Pano LP)","field_type":"metric","group":"Custom","slug":"test_leads_goal","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"merge(facebook_ads|effective_status,adwords|campaign_state,linkedin|status,appnexus|campaign_state
-        )","data_type":"text","description":"Custom Field. The status of your campaign
-        - example statuses are pending, active, inactive, and ended.","display_format":"decimal_2","display_name":"Campaign
-        Status","field_type":"dimension","group":"Custom","slug":"campaign_status_pano","taxon_type":"dimension"},{"aggregation":{"type":"avg"},"aggregation_type":"avg","calculation":"5","data_type":"money","description":null,"display_format":"usd_2","display_name":"Max''s
-        Benchmark","field_type":"metric","group":"Custom","slug":"max_s_benchmark","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"contact_property_history_value","field_type":"dimension","group":"CLI","slug":"hubspot|contact_property_history_value","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_format":null,"display_name":"contact_property_history_name","field_type":"dimension","group":"CLI","slug":"hubspot|contact_property_history_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_event_id","field_type":"dimension","group":"CLI","slug":"hubspot|email_event_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"created","field_type":"dimension","group":"CLI","slug":"hubspot|created","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_event_type","field_type":"dimension","group":"CLI","slug":"hubspot|email_event_type","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"app_id","field_type":"metric","group":"CLI","slug":"hubspot|app_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"filtered_event","field_type":"dimension","group":"CLI","slug":"hubspot|filtered_event","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"email_campaign_id","field_type":"metric","group":"CLI","slug":"hubspot|email_campaign_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"sent_by_id","field_type":"dimension","group":"CLI","slug":"hubspot|sent_by_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"sent_by_created","field_type":"dimension","group":"CLI","slug":"hubspot|sent_by_created","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"caused_by_id","field_type":"dimension","group":"CLI","slug":"hubspot|caused_by_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"caused_by_created","field_type":"dimension","group":"CLI","slug":"hubspot|caused_by_created","taxon_type":"dimension"},{"aggregation":{"type":"avg"},"aggregation_type":"avg","calculation":"panoramic_z5y1clyi__clicks_to_lp
-        / impressions","data_type":"percent","description":"Click Through Rate to
-        Landing Page","display_format":"percent_2","display_name":"CTR (LP)","field_type":"metric","group":"Custom","slug":"lp_click_rate","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"engagement_id","field_type":"metric","group":"CLI","slug":"hubspot|engagement_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"body","field_type":"dimension","group":"CLI","slug":"hubspot|body","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"start_time","field_type":"dimension","group":"CLI","slug":"hubspot|start_time","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"end_time","field_type":"dimension","group":"CLI","slug":"hubspot|end_time","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"engagement_meeting_title","field_type":"dimension","group":"CLI","slug":"hubspot|engagement_meeting_title","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"external_url","field_type":"dimension","group":"CLI","slug":"hubspot|external_url","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"created_from_link_id","field_type":"metric","group":"CLI","slug":"hubspot|created_from_link_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"web_conference_meeting_id","field_type":"dimension","group":"CLI","slug":"hubspot|web_conference_meeting_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"pre_meeting_prospect_reminders","field_type":"dimension","group":"CLI","slug":"hubspot|pre_meeting_prospect_reminders","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_event_status_change_id","field_type":"dimension","group":"CLI","slug":"hubspot|email_event_status_change_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"requested_by","field_type":"dimension","group":"CLI","slug":"hubspot|requested_by","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"portal_subscription_status","field_type":"dimension","group":"CLI","slug":"hubspot|portal_subscription_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"subscriptions","field_type":"dimension","group":"CLI","slug":"hubspot|subscriptions","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"bounced","field_type":"dimension","group":"CLI","slug":"hubspot|bounced","taxon_type":"dimension"},{"calculation":null,"data_source":"test_dataset","data_type":"text","description":null,"display_name":"name","field_type":"dimension","group":"CLI","slug":"test_dataset|name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_event_open_id","field_type":"dimension","group":"CLI","slug":"hubspot|email_event_open_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"duration","field_type":"dimension","group":"CLI","slug":"hubspot|duration","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"redirect","field_type":"dimension","group":"CLI","slug":"hubspot|redirect","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"submit_text","field_type":"dimension","group":"CLI","slug":"hubspot|submit_text","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"follow_up_id","field_type":"dimension","group":"CLI","slug":"hubspot|follow_up_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"notify_recipients","field_type":"dimension","group":"CLI","slug":"hubspot|notify_recipients","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"lead_nurturing_campaign_id","field_type":"dimension","group":"CLI","slug":"hubspot|lead_nurturing_campaign_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"created_at","field_type":"dimension","group":"CLI","slug":"hubspot|created_at","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"updated_at","field_type":"dimension","group":"CLI","slug":"hubspot|updated_at","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"_fivetran_deleted","field_type":"dimension","group":"CLI","slug":"hubspot|_fivetran_deleted","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"_fivetran_synced","field_type":"dimension","group":"CLI","slug":"hubspot|_fivetran_synced","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_event_deferred_id","field_type":"dimension","group":"CLI","slug":"hubspot|email_event_deferred_id","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"attempt","field_type":"metric","group":"CLI","slug":"hubspot|attempt","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"pipeline_id","field_type":"dimension","group":"CLI","slug":"hubspot|pipeline_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"label","field_type":"dimension","group":"CLI","slug":"hubspot|label","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"active","field_type":"dimension","group":"CLI","slug":"hubspot|active","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"display_order","field_type":"metric","group":"CLI","slug":"hubspot|display_order","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"deal_id","field_type":"metric","group":"CLI","slug":"hubspot|deal_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"deal_property_history_name","field_type":"dimension","group":"CLI","slug":"hubspot|deal_property_history_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"timestamp","field_type":"dimension","group":"CLI","slug":"hubspot|timestamp","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"deal_property_history_value","field_type":"dimension","group":"CLI","slug":"hubspot|deal_property_history_value","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"source_id","field_type":"dimension","group":"CLI","slug":"hubspot|source_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"source","field_type":"dimension","group":"CLI","slug":"hubspot|source","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"identity_vid","field_type":"dimension","group":"CLI","slug":"hubspot|identity_vid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"identity_profile_identity_value","field_type":"dimension","group":"CLI","slug":"hubspot|identity_profile_identity_value","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"identity_profile_identity_type","field_type":"dimension","group":"CLI","slug":"hubspot|identity_profile_identity_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"is_primary","field_type":"dimension","group":"CLI","slug":"hubspot|is_primary","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"is_secondary","field_type":"dimension","group":"CLI","slug":"hubspot|is_secondary","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"conversion_id","field_type":"dimension","group":"CLI","slug":"hubspot|conversion_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"contact_form_submission_title","field_type":"dimension","group":"CLI","slug":"hubspot|contact_form_submission_title","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"form_id","field_type":"dimension","group":"CLI","slug":"hubspot|form_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"page_url","field_type":"dimension","group":"CLI","slug":"hubspot|page_url","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"company_id","field_type":"metric","group":"CLI","slug":"hubspot|company_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"company_property_history_name","field_type":"dimension","group":"CLI","slug":"hubspot|company_property_history_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"company_property_history_value","field_type":"dimension","group":"CLI","slug":"hubspot|company_property_history_value","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"thread_id","field_type":"dimension","group":"CLI","slug":"hubspot|thread_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"engagement_email_status","field_type":"dimension","group":"CLI","slug":"hubspot|engagement_email_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"sent_via","field_type":"dimension","group":"CLI","slug":"hubspot|sent_via","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"logged_from","field_type":"dimension","group":"CLI","slug":"hubspot|logged_from","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"error_message","field_type":"dimension","group":"CLI","slug":"hubspot|error_message","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"facsimile_send_id","field_type":"dimension","group":"CLI","slug":"hubspot|facsimile_send_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"post_send_status","field_type":"dimension","group":"CLI","slug":"hubspot|post_send_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"media_processing_status","field_type":"dimension","group":"CLI","slug":"hubspot|media_processing_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"attached_video_opened","field_type":"dimension","group":"CLI","slug":"hubspot|attached_video_opened","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"attached_video_watched","field_type":"dimension","group":"CLI","slug":"hubspot|attached_video_watched","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"attached_video_id","field_type":"dimension","group":"CLI","slug":"hubspot|attached_video_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"recipient_drop_reasons","field_type":"dimension","group":"CLI","slug":"hubspot|recipient_drop_reasons","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"validation_skipped","field_type":"dimension","group":"CLI","slug":"hubspot|validation_skipped","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"email_send_event_id_created","field_type":"dimension","group":"CLI","slug":"hubspot|email_send_event_id_created","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_send_event_id_id","field_type":"dimension","group":"CLI","slug":"hubspot|email_send_event_id_id","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"owner_id","field_type":"metric","group":"CLI","slug":"hubspot|owner_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"owner_type","field_type":"dimension","group":"CLI","slug":"hubspot|owner_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"first_name","field_type":"dimension","group":"CLI","slug":"hubspot|first_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"last_name","field_type":"dimension","group":"CLI","slug":"hubspot|last_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email","field_type":"dimension","group":"CLI","slug":"hubspot|email","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"unknown_visitor_conversation","field_type":"dimension","group":"CLI","slug":"hubspot|unknown_visitor_conversation","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"campaign_guid","field_type":"dimension","group":"CLI","slug":"hubspot|campaign_guid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"calendar_event_name","field_type":"dimension","group":"CLI","slug":"hubspot|calendar_event_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"description","field_type":"dimension","group":"CLI","slug":"hubspot|description","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"url","field_type":"dimension","group":"CLI","slug":"hubspot|url","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"created_by","field_type":"metric","group":"CLI","slug":"hubspot|created_by","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"create_content","field_type":"dimension","group":"CLI","slug":"hubspot|create_content","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"preview_key","field_type":"dimension","group":"CLI","slug":"hubspot|preview_key","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"template_path","field_type":"dimension","group":"CLI","slug":"hubspot|template_path","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"social_username","field_type":"dimension","group":"CLI","slug":"hubspot|social_username","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"social_display_name","field_type":"dimension","group":"CLI","slug":"hubspot|social_display_name","taxon_type":"dimension"}]}
-
-        '
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '22795'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Nov 2020 15:10:19 GMT
+      - Fri, 20 Nov 2020 11:28:46 GMT
       Via:
       - kong/2.0.3
       X-Amzn-Trace-Id:
@@ -360,246 +251,9 @@ interactions:
       X-Kong-Proxy-Latency:
       - '0'
       X-Kong-Upstream-Latency:
-      - '93'
+      - '42'
       x-diesel-request-id:
-      - 1819e12b-3d05-4989-ab77-749364f0a63f
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - pano-cli/1.2.0
-    method: GET
-    uri: https://diesel.panoramicapi.com/api/v1/federated/taxonomy/taxons?company_slug=panoramic-z5y1clyi&offset=200&limit=100
-  response:
-    body:
-      string: '{"data":[{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"avatar_url","field_type":"dimension","group":"CLI","slug":"hubspot|avatar_url","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"is_recurring","field_type":"dimension","group":"CLI","slug":"hubspot|is_recurring","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"topic_ids","field_type":"dimension","group":"CLI","slug":"hubspot|topic_ids","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"content_group_id","field_type":"dimension","group":"CLI","slug":"hubspot|content_group_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"group_id","field_type":"dimension","group":"CLI","slug":"hubspot|group_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"group_order","field_type":"dimension","group":"CLI","slug":"hubspot|group_order","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"user_ids","field_type":"dimension","group":"CLI","slug":"hubspot|user_ids","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"user_id","field_type":"metric","group":"CLI","slug":"hubspot|user_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"engagement_task_status","field_type":"dimension","group":"CLI","slug":"hubspot|engagement_task_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"for_object_type","field_type":"dimension","group":"CLI","slug":"hubspot|for_object_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"task_type","field_type":"dimension","group":"CLI","slug":"hubspot|task_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"is_all_day","field_type":"dimension","group":"CLI","slug":"hubspot|is_all_day","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"priority","field_type":"dimension","group":"CLI","slug":"hubspot|priority","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"completion_date","field_type":"metric","group":"CLI","slug":"hubspot|completion_date","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"stage_id","field_type":"dimension","group":"CLI","slug":"hubspot|stage_id","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"probability","field_type":"metric","group":"CLI","slug":"hubspot|probability","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"closed_won","field_type":"dimension","group":"CLI","slug":"hubspot|closed_won","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_closed_amount_in_home_currency","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_closed_amount_in_home_currency","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_brand_or_agency_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_brand_or_agency_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_amount_in_home_currency","field_type":"metric","group":"CLI","slug":"hubspot|property_amount_in_home_currency","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_connectors_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_connectors_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_days_to_close","field_type":"metric","group":"CLI","slug":"hubspot|property_days_to_close","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_budget_confirmed_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_budget_confirmed_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_competitor_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_competitor_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_analytics_source","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_source","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_discovery_completed_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_discovery_completed_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_closed_amount","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_closed_amount","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_data_warehouse_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_data_warehouse_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_budget_c","field_type":"metric","group":"CLI","slug":"hubspot|property_budget_c","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_contract_amount_c","field_type":"metric","group":"CLI","slug":"hubspot|property_contract_amount_c","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_billing_terms_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_billing_terms_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_contract_renewal_date_c","field_type":"metric","group":"CLI","slug":"hubspot|property_contract_renewal_date_c","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_contact_s_first_name_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_contact_s_first_name_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_contact_s_last_name_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_contact_s_last_name_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_contact_s_title_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_contact_s_title_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_created_by_user_id","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_created_by_user_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_contract_type_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_contract_type_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_deal_stage_probability","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_deal_stage_probability","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_projected_amount","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_projected_amount","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_lastmodifieddate","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_lastmodifieddate","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_hs_is_closed","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_is_closed","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_projected_amount_in_home_currency","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_projected_amount_in_home_currency","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_salesforceopportunityid","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_salesforceopportunityid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_merged_object_ids","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_merged_object_ids","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_verified_sal_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_verified_sal_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_sal_amount_total_c","field_type":"metric","group":"CLI","slug":"hubspot|property_sal_amount_total_c","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_opportunity_type_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_opportunity_type_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_opportunity_won_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_opportunity_won_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"deal_pipeline_id","field_type":"dimension","group":"CLI","slug":"hubspot|deal_pipeline_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hubspot_owner_assigneddate","field_type":"dimension","group":"CLI","slug":"hubspot|property_hubspot_owner_assigneddate","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_salesforcelastsynctime","field_type":"dimension","group":"CLI","slug":"hubspot|property_salesforcelastsynctime","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_dealname","field_type":"dimension","group":"CLI","slug":"hubspot|property_dealname","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_closedate","field_type":"dimension","group":"CLI","slug":"hubspot|property_closedate","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_referrer_paid_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_referrer_paid_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_sal_recorded_month_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_sal_recorded_month_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_createdate","field_type":"dimension","group":"CLI","slug":"hubspot|property_createdate","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_roi_analysis_completed_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_roi_analysis_completed_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"deal_pipeline_stage_id","field_type":"dimension","group":"CLI","slug":"hubspot|deal_pipeline_stage_id","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_sal_amount_oustanding_c","field_type":"metric","group":"CLI","slug":"hubspot|property_sal_amount_oustanding_c","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_amount","field_type":"metric","group":"CLI","slug":"hubspot|property_amount","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_originator_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_originator_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_sal_amount_paid_c","field_type":"metric","group":"CLI","slug":"hubspot|property_sal_amount_paid_c","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_sal_paid_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_sal_paid_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_loss_reason_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_loss_reason_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_sales_forecast_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_sales_forecast_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_updated_by_user_id","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_updated_by_user_id","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_user_ids_of_all_owners","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_user_ids_of_all_owners","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_referrer_name_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_referrer_name_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_notes_last_updated","field_type":"dimension","group":"CLI","slug":"hubspot|property_notes_last_updated","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_referrer_to_be_paid_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_referrer_to_be_paid_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_referral_amount_unpaid_c","field_type":"metric","group":"CLI","slug":"hubspot|property_referral_amount_unpaid_c","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_payment_terms_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_payment_terms_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_ref_c","field_type":"metric","group":"CLI","slug":"hubspot|property_ref_c","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_referral_amount_paid_c","field_type":"metric","group":"CLI","slug":"hubspot|property_referral_amount_paid_c","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_notes_from_bryan","field_type":"dimension","group":"CLI","slug":"hubspot|property_notes_from_bryan","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_notes_next_steps","field_type":"dimension","group":"CLI","slug":"hubspot|property_notes_next_steps","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_notes_last_contacted","field_type":"dimension","group":"CLI","slug":"hubspot|property_notes_last_contacted","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_sales_email_last_replied","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_sales_email_last_replied","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_latest_meeting_activity","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_latest_meeting_activity","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_dealtype","field_type":"dimension","group":"CLI","slug":"hubspot|property_dealtype","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_createdate","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_createdate","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_all_owner_ids","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_all_owner_ids","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_description","field_type":"dimension","group":"CLI","slug":"hubspot|property_description","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hubspot_team_id","field_type":"metric","group":"CLI","slug":"hubspot|property_hubspot_team_id","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_all_team_ids","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_all_team_ids","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_all_accessible_team_ids","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_all_accessible_team_ids","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_num_notes","field_type":"metric","group":"CLI","slug":"hubspot|property_num_notes","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_num_contacted_notes","field_type":"metric","group":"CLI","slug":"hubspot|property_num_contacted_notes","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_notes_next_activity_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_notes_next_activity_date","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_num_associated_contacts","field_type":"metric","group":"CLI","slug":"hubspot|property_num_associated_contacts","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_analytics_first_timestamp","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_first_timestamp","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_num_contacts_with_buying_roles","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_num_contacts_with_buying_roles","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_name","field_type":"dimension","group":"CLI","slug":"hubspot|property_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_linkedinbio","field_type":"dimension","group":"CLI","slug":"hubspot|property_linkedinbio","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_founded_year","field_type":"metric","group":"CLI","slug":"hubspot|property_founded_year","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_timezone","field_type":"dimension","group":"CLI","slug":"hubspot|property_timezone","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_total_money_raised","field_type":"dimension","group":"CLI","slug":"hubspot|property_total_money_raised","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_city","field_type":"dimension","group":"CLI","slug":"hubspot|property_city","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_analytics_num_page_views","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_analytics_num_page_views","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_num_decision_makers","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_num_decision_makers","taxon_type":"metric"}]}
-
-        '
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '24900'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Nov 2020 15:10:19 GMT
-      Via:
-      - kong/2.0.3
-      X-Amzn-Trace-Id:
-      - None
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '347'
-      x-diesel-request-id:
-      - 6e48005b-7dc8-4790-8a69-3c8254eb2754
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - pano-cli/1.2.0
-    method: GET
-    uri: https://diesel.panoramicapi.com/api/v1/federated/taxonomy/taxons?company_slug=panoramic-z5y1clyi&offset=300&limit=100
-  response:
-    body:
-      string: '{"data":[{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_panoramic_client_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_panoramic_client_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_num_open_deals","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_num_open_deals","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_salesforceaccountid","field_type":"dimension","group":"CLI","slug":"hubspot|property_salesforceaccountid","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_num_blockers","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_num_blockers","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_facebook_company_page","field_type":"dimension","group":"CLI","slug":"hubspot|property_facebook_company_page","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_analytics_num_visits","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_analytics_num_visits","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_operam_client_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_operam_client_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_address","field_type":"dimension","group":"CLI","slug":"hubspot|property_address","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_current_client_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_current_client_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_linkedin_company_page","field_type":"dimension","group":"CLI","slug":"hubspot|property_linkedin_company_page","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_total_deal_value","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_total_deal_value","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_target_account_probability","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_target_account_probability","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_is_public","field_type":"dimension","group":"CLI","slug":"hubspot|property_is_public","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_twitterhandle","field_type":"dimension","group":"CLI","slug":"hubspot|property_twitterhandle","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_account_number_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_account_number_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_phone","field_type":"dimension","group":"CLI","slug":"hubspot|property_phone","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_lead_number_c","field_type":"metric","group":"CLI","slug":"hubspot|property_lead_number_c","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_address_2","field_type":"dimension","group":"CLI","slug":"hubspot|property_address_2","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_lfapp_view_in_leadfeeder","field_type":"dimension","group":"CLI","slug":"hubspot|property_lfapp_view_in_leadfeeder","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_num_associated_deals","field_type":"metric","group":"CLI","slug":"hubspot|property_num_associated_deals","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_first_deal_created_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_first_deal_created_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_analytics_last_visit_timestamp","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_last_visit_timestamp","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_analytics_first_visit_timestamp","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_first_visit_timestamp","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_analytics_last_timestamp","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_last_timestamp","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_last_booked_meeting_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_last_booked_meeting_date","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_num_conversion_events","field_type":"metric","group":"CLI","slug":"hubspot|property_num_conversion_events","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_first_conversion_event_name","field_type":"dimension","group":"CLI","slug":"hubspot|property_first_conversion_event_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_recent_conversion_event_name","field_type":"dimension","group":"CLI","slug":"hubspot|property_recent_conversion_event_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_recent_conversion_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_recent_conversion_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_first_conversion_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_first_conversion_date","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_total_revenue","field_type":"metric","group":"CLI","slug":"hubspot|property_total_revenue","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_recent_deal_close_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_recent_deal_close_date","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_recent_deal_amount","field_type":"metric","group":"CLI","slug":"hubspot|property_recent_deal_amount","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_media_spend_c","field_type":"metric","group":"CLI","slug":"hubspot|property_media_spend_c","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_last_open_task_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_last_open_task_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_lfapp_latest_visit","field_type":"dimension","group":"CLI","slug":"hubspot|property_lfapp_latest_visit","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_salesforcedeleted","field_type":"dimension","group":"CLI","slug":"hubspot|property_salesforcedeleted","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_last_sales_activity_timestamp","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_last_sales_activity_timestamp","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_last_sales_activity_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_last_sales_activity_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_last_logged_call_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_last_logged_call_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_domain","field_type":"dimension","group":"CLI","slug":"hubspot|property_domain","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_industry","field_type":"dimension","group":"CLI","slug":"hubspot|property_industry","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_zip","field_type":"dimension","group":"CLI","slug":"hubspot|property_zip","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_website","field_type":"dimension","group":"CLI","slug":"hubspot|property_website","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_state","field_type":"dimension","group":"CLI","slug":"hubspot|property_state","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_web_technologies","field_type":"dimension","group":"CLI","slug":"hubspot|property_web_technologies","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_country","field_type":"dimension","group":"CLI","slug":"hubspot|property_country","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hubspot_owner_id","field_type":"metric","group":"CLI","slug":"hubspot|property_hubspot_owner_id","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_annualrevenue","field_type":"metric","group":"CLI","slug":"hubspot|property_annualrevenue","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_first_contact_createdate","field_type":"dimension","group":"CLI","slug":"hubspot|property_first_contact_createdate","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_numberofemployees","field_type":"metric","group":"CLI","slug":"hubspot|property_numberofemployees","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_type","field_type":"dimension","group":"CLI","slug":"hubspot|property_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_lifecyclestage","field_type":"dimension","group":"CLI","slug":"hubspot|property_lifecyclestage","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_num_child_companies","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_num_child_companies","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_analytics_last_touch_converting_campaign","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_last_touch_converting_campaign","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_analytics_first_touch_converting_campaign","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_first_touch_converting_campaign","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"obsoleted_by_id","field_type":"dimension","group":"CLI","slug":"hubspot|obsoleted_by_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"obsoleted_by_created","field_type":"dimension","group":"CLI","slug":"hubspot|obsoleted_by_created","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"browser","field_type":"dimension","group":"CLI","slug":"hubspot|browser","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"location","field_type":"dimension","group":"CLI","slug":"hubspot|location","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"referer","field_type":"dimension","group":"CLI","slug":"hubspot|referer","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_subscription_name","field_type":"dimension","group":"CLI","slug":"hubspot|email_subscription_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_event_bounce_id","field_type":"dimension","group":"CLI","slug":"hubspot|email_event_bounce_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"response","field_type":"dimension","group":"CLI","slug":"hubspot|response","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_event_bounce_status","field_type":"dimension","group":"CLI","slug":"hubspot|email_event_bounce_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_event_sent_id","field_type":"dimension","group":"CLI","slug":"hubspot|email_event_sent_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"from","field_type":"dimension","group":"CLI","slug":"hubspot|from","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"reply_to","field_type":"dimension","group":"CLI","slug":"hubspot|reply_to","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"cc","field_type":"dimension","group":"CLI","slug":"hubspot|cc","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"bcc","field_type":"dimension","group":"CLI","slug":"hubspot|bcc","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"canonical_vid","field_type":"metric","group":"CLI","slug":"hubspot|canonical_vid","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"merged_vids","field_type":"dimension","group":"CLI","slug":"hubspot|merged_vids","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"profile_url","field_type":"dimension","group":"CLI","slug":"hubspot|profile_url","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_assistant_email_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_assistant_email_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_assistant_s_first_name_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_assistant_s_first_name_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_assistant_s_last_name_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_assistant_s_last_name_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_company_size","field_type":"dimension","group":"CLI","slug":"hubspot|property_company_size","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_customer_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_customer_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_data_source_1","field_type":"dimension","group":"CLI","slug":"hubspot|property_data_source_1","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_data_source_2","field_type":"dimension","group":"CLI","slug":"hubspot|property_data_source_2","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_date_of_birth","field_type":"dimension","group":"CLI","slug":"hubspot|property_date_of_birth","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_degree","field_type":"dimension","group":"CLI","slug":"hubspot|property_degree","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_detail_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_detail_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_email_bounced_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_email_bounced_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_field_of_study","field_type":"dimension","group":"CLI","slug":"hubspot|property_field_of_study","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_form_offer","field_type":"dimension","group":"CLI","slug":"hubspot|property_form_offer","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_full_name","field_type":"dimension","group":"CLI","slug":"hubspot|property_full_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_gender","field_type":"dimension","group":"CLI","slug":"hubspot|property_gender","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_graduation_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_graduation_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_avatar_filemanager_key","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_avatar_filemanager_key","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_buying_role","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_buying_role","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_content_membership_notes","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_content_membership_notes","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_content_membership_registration_domain_sent_to","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_content_membership_registration_domain_sent_to","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_content_membership_status","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_content_membership_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_conversations_visitor_email","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_conversations_visitor_email","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_email_hard_bounce_reason","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_hard_bounce_reason","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_email_hard_bounce_reason_enum","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_hard_bounce_reason_enum","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_email_quarantined_reason","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_quarantined_reason","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_emailconfirmationstatus","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_emailconfirmationstatus","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_facebook_click_id","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_facebook_click_id","taxon_type":"dimension"}]}
-
-        '
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '24226'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Nov 2020 15:10:20 GMT
-      Via:
-      - kong/2.0.3
-      X-Amzn-Trace-Id:
-      - None
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '83'
-      x-diesel-request-id:
-      - 0a20fa97-4591-4ad6-bda6-58635cd3e349
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - pano-cli/1.2.0
-    method: GET
-    uri: https://diesel.panoramicapi.com/api/v1/federated/taxonomy/taxons?company_slug=panoramic-z5y1clyi&offset=400&limit=100
-  response:
-    body:
-      string: '{"data":[{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_facebookid","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_facebookid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_feedback_last_nps_follow_up","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_feedback_last_nps_follow_up","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_feedback_last_nps_rating","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_feedback_last_nps_rating","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_first_engagement_descr","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_first_engagement_descr","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_first_engagement_object_type","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_first_engagement_object_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_google_click_id","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_google_click_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_googleplusid","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_googleplusid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_ip_timezone","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_ip_timezone","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_lead_status","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_lead_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_legal_basis","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_legal_basis","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_linkedinid","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_linkedinid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_marketable_reason_id","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_marketable_reason_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_marketable_reason_type","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_marketable_reason_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_marketable_status","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_marketable_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_marketable_until_renewal","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_marketable_until_renewal","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_predictivescoringtier","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_predictivescoringtier","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_twitterid","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_twitterid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_ip_city","field_type":"dimension","group":"CLI","slug":"hubspot|property_ip_city","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_ip_country","field_type":"dimension","group":"CLI","slug":"hubspot|property_ip_country","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_ip_country_code","field_type":"dimension","group":"CLI","slug":"hubspot|property_ip_country_code","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_ip_latlon","field_type":"dimension","group":"CLI","slug":"hubspot|property_ip_latlon","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_ip_state","field_type":"dimension","group":"CLI","slug":"hubspot|property_ip_state","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_ip_state_code","field_type":"dimension","group":"CLI","slug":"hubspot|property_ip_state_code","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_ip_zipcode","field_type":"dimension","group":"CLI","slug":"hubspot|property_ip_zipcode","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_job_function","field_type":"dimension","group":"CLI","slug":"hubspot|property_job_function","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_job_level","field_type":"dimension","group":"CLI","slug":"hubspot|property_job_level","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_lead_notes_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_lead_notes_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_leadsource","field_type":"dimension","group":"CLI","slug":"hubspot|property_leadsource","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_leadstatus","field_type":"dimension","group":"CLI","slug":"hubspot|property_leadstatus","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_linkedin_profile_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_linkedin_profile_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_marital_status","field_type":"dimension","group":"CLI","slug":"hubspot|property_marital_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_marketer_or_agency_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_marketer_or_agency_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_military_status","field_type":"dimension","group":"CLI","slug":"hubspot|property_military_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_multiple_company_divisions_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_multiple_company_divisions_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_operam_account_lead_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_operam_account_lead_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_opportunitytype_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_opportunitytype_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_persona_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_persona_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_platform_user_type_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_platform_user_type_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_rating","field_type":"dimension","group":"CLI","slug":"hubspot|property_rating","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_referral_origin_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_referral_origin_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_referrer_company_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_referrer_company_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_relationship_status","field_type":"dimension","group":"CLI","slug":"hubspot|property_relationship_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_salesforcecampaignids","field_type":"dimension","group":"CLI","slug":"hubspot|property_salesforcecampaignids","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_salesforcecontactid","field_type":"dimension","group":"CLI","slug":"hubspot|property_salesforcecontactid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_salesforceleadid","field_type":"dimension","group":"CLI","slug":"hubspot|property_salesforceleadid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_salesforceopportunitystage","field_type":"dimension","group":"CLI","slug":"hubspot|property_salesforceopportunitystage","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_salesforceownerid","field_type":"dimension","group":"CLI","slug":"hubspot|property_salesforceownerid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_school","field_type":"dimension","group":"CLI","slug":"hubspot|property_school","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_seniority","field_type":"dimension","group":"CLI","slug":"hubspot|property_seniority","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_sfcampaignid","field_type":"dimension","group":"CLI","slug":"hubspot|property_sfcampaignid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_source_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_source_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_stage_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_stage_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_start_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_start_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_submitterip_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_submitterip_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_type_of_media_relationship_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_type_of_media_relationship_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_unbouncepageid_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_unbouncepageid_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_unbouncepagevariant_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_unbouncepagevariant_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_unbouncesubmissiondate_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_unbouncesubmissiondate_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_unbouncesubmissiontime_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_unbouncesubmissiontime_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_utm_campaign","field_type":"dimension","group":"CLI","slug":"hubspot|property_utm_campaign","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_utm_medium","field_type":"dimension","group":"CLI","slug":"hubspot|property_utm_medium","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_utm_source","field_type":"dimension","group":"CLI","slug":"hubspot|property_utm_source","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_utm_term","field_type":"dimension","group":"CLI","slug":"hubspot|property_utm_term","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_want_demo","field_type":"dimension","group":"CLI","slug":"hubspot|property_want_demo","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_work_email","field_type":"dimension","group":"CLI","slug":"hubspot|property_work_email","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_firstname","field_type":"dimension","group":"CLI","slug":"hubspot|property_firstname","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_analytics_first_url","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_first_url","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_email_optout_7903713","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_optout_7903713","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_email_optout_9573350","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_optout_9573350","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_currentlyinworkflow","field_type":"dimension","group":"CLI","slug":"hubspot|property_currentlyinworkflow","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_analytics_last_url","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_last_url","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_lastname","field_type":"dimension","group":"CLI","slug":"hubspot|property_lastname","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_salutation","field_type":"dimension","group":"CLI","slug":"hubspot|property_salutation","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_twitterprofilephoto","field_type":"dimension","group":"CLI","slug":"hubspot|property_twitterprofilephoto","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_persona","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_persona","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_mobilephone","field_type":"dimension","group":"CLI","slug":"hubspot|property_mobilephone","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_fax","field_type":"dimension","group":"CLI","slug":"hubspot|property_fax","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_email_last_email_name","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_last_email_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_engagements_last_meeting_booked_campaign","field_type":"dimension","group":"CLI","slug":"hubspot|property_engagements_last_meeting_booked_campaign","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_engagements_last_meeting_booked_medium","field_type":"dimension","group":"CLI","slug":"hubspot|property_engagements_last_meeting_booked_medium","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_engagements_last_meeting_booked_source","field_type":"dimension","group":"CLI","slug":"hubspot|property_engagements_last_meeting_booked_source","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_owneremail","field_type":"dimension","group":"CLI","slug":"hubspot|property_owneremail","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_ownername","field_type":"dimension","group":"CLI","slug":"hubspot|property_ownername","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_twitterbio","field_type":"dimension","group":"CLI","slug":"hubspot|property_twitterbio","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_language","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_language","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_analytics_first_referrer","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_first_referrer","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_jobtitle","field_type":"dimension","group":"CLI","slug":"hubspot|property_jobtitle","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_photo","field_type":"dimension","group":"CLI","slug":"hubspot|property_photo","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_analytics_last_referrer","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_last_referrer","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_message","field_type":"dimension","group":"CLI","slug":"hubspot|property_message","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_company","field_type":"dimension","group":"CLI","slug":"hubspot|property_company","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_numemployees","field_type":"dimension","group":"CLI","slug":"hubspot|property_numemployees","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_predictivecontactscorebucket","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_predictivecontactscorebucket","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_analytics_revenue","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_analytics_revenue","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_hs_email_quarantined","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_quarantined","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_hs_is_unworked","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_is_unworked","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_analytics_average_page_views","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_analytics_average_page_views","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_associatedcompanyid","field_type":"metric","group":"CLI","slug":"hubspot|property_associatedcompanyid","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_analytics_num_event_completions","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_analytics_num_event_completions","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_social_facebook_clicks","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_social_facebook_clicks","taxon_type":"metric"}]}
-
-        '
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '23716'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Nov 2020 15:10:21 GMT
-      Via:
-      - kong/2.0.3
-      X-Amzn-Trace-Id:
-      - None
-      X-Kong-Proxy-Latency:
-      - '0'
-      X-Kong-Upstream-Latency:
-      - '293'
-      x-diesel-request-id:
-      - 22ce94c2-6042-4edc-94d8-ab3a233c9ab2
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - pano-cli/1.2.0
-    method: GET
-    uri: https://diesel.panoramicapi.com/api/v1/federated/taxonomy/taxons?company_slug=panoramic-z5y1clyi&offset=500&limit=100
-  response:
-    body:
-      string: '{"data":[{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_social_last_engagement","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_social_last_engagement","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_social_google_plus_clicks","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_social_google_plus_clicks","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_social_linkedin_clicks","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_social_linkedin_clicks","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_lastmodifieddate","field_type":"dimension","group":"CLI","slug":"hubspot|property_lastmodifieddate","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_hs_email_optout","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_optout","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_social_num_broadcast_clicks","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_social_num_broadcast_clicks","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_lifecyclestage_lead_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_lifecyclestage_lead_date","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_social_twitter_clicks","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_social_twitter_clicks","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_email_first_send_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_first_send_date","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_email_delivered","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_email_delivered","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_email_first_open_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_first_open_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_email_last_send_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_last_send_date","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_email_sends_since_last_engagement","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_email_sends_since_last_engagement","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_email_open","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_email_open","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_email_last_open_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_last_open_date","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_email_bounce","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_email_bounce","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_email_first_click_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_first_click_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_email_last_click_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_last_click_date","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_email_click","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_email_click","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_lifecyclestage_other_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_lifecyclestage_other_date","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_time_to_first_engagement","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_time_to_first_engagement","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_lifecyclestage_opportunity_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_lifecyclestage_opportunity_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_hs_facebook_ad_clicked","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_facebook_ad_clicked","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_lifecyclestage_subscriber_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_lifecyclestage_subscriber_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_hs_email_bad_address","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_bad_address","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_first_engagement_object_id","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_first_engagement_object_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_hs_created_by_conversations","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_created_by_conversations","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_sales_email_last_opened","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_sales_email_last_opened","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_sa_first_engagement_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_sa_first_engagement_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_facebook_lead_id","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_facebook_lead_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_marketing_pain_point","field_type":"dimension","group":"CLI","slug":"hubspot|property_marketing_pain_point","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_what_benefit_would_help_your_marketing_team_the_most_right_now_","field_type":"dimension","group":"CLI","slug":"hubspot|property_what_benefit_would_help_your_marketing_team_the_most_right_now_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_what_industry_are_you_in_","field_type":"dimension","group":"CLI","slug":"hubspot|property_what_industry_are_you_in_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_what_is_your_biggest_marketing_pain_point_","field_type":"dimension","group":"CLI","slug":"hubspot|property_what_is_your_biggest_marketing_pain_point_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_what_is_your_role_on_the_team_","field_type":"dimension","group":"CLI","slug":"hubspot|property_what_is_your_role_on_the_team_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_role","field_type":"dimension","group":"CLI","slug":"hubspot|property_role","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_department","field_type":"dimension","group":"CLI","slug":"hubspot|property_department","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_how_do_you_currently_store_your_marketing_data_","field_type":"dimension","group":"CLI","slug":"hubspot|property_how_do_you_currently_store_your_marketing_data_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_how_long_does_it_take_to_group_map_and_model_all_of_your_data_","field_type":"dimension","group":"CLI","slug":"hubspot|property_how_long_does_it_take_to_group_map_and_model_all_of_your_data_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_does_your_marketing_or_analytics_team_want_to_do_any_of_the_following_","field_type":"dimension","group":"CLI","slug":"hubspot|property_does_your_marketing_or_analytics_team_want_to_do_any_of_the_following_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_how_do_you_currently_pull_or_extract_your_marketing_data_","field_type":"dimension","group":"CLI","slug":"hubspot|property_how_do_you_currently_pull_or_extract_your_marketing_data_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_how_do_you_store_your_marketing_data_","field_type":"dimension","group":"CLI","slug":"hubspot|property_how_do_you_store_your_marketing_data_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_what_part_do_you_play_on_the_team_","field_type":"dimension","group":"CLI","slug":"hubspot|property_what_part_do_you_play_on_the_team_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_how_long_does_it_take_you_to_group_map_and_model_your_data_","field_type":"dimension","group":"CLI","slug":"hubspot|property_how_long_does_it_take_you_to_group_map_and_model_your_data_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_how_do_you_currently_extract_or_pull_marketing_data_","field_type":"dimension","group":"CLI","slug":"hubspot|property_how_do_you_currently_extract_or_pull_marketing_data_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_would_you_like_to_take_a_quiz_to_see_how_panoramic_can_help_you_","field_type":"dimension","group":"CLI","slug":"hubspot|property_would_you_like_to_take_a_quiz_to_see_how_panoramic_can_help_you_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_what_is_your_industry_","field_type":"dimension","group":"CLI","slug":"hubspot|property_what_is_your_industry_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_would_you_like_to_do_any_of_the_following_","field_type":"dimension","group":"CLI","slug":"hubspot|property_would_you_like_to_do_any_of_the_following_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_ok_well_let_s_at_least_stay_in_touch_","field_type":"dimension","group":"CLI","slug":"hubspot|property_ok_well_let_s_at_least_stay_in_touch_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_forrester_paper","field_type":"dimension","group":"CLI","slug":"hubspot|property_forrester_paper","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_event_dropped_id","field_type":"dimension","group":"CLI","slug":"hubspot|email_event_dropped_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"drop_reason","field_type":"dimension","group":"CLI","slug":"hubspot|drop_reason","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"drop_message","field_type":"dimension","group":"CLI","slug":"hubspot|drop_message","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"facebook_ads|actions__offsite_conversion_fb_pixel_complete_registration_value
-        ","data_type":"numeric","description":"The number of invites scheduled with
-        Sales.","display_format":"decimal_0","display_name":"Calendy Invites","field_type":"metric","group":"Custom","slug":"calendy_invites","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"fivetran_audit_id","field_type":"dimension","group":"CLI","slug":"hubspot|fivetran_audit_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"message","field_type":"dimension","group":"CLI","slug":"hubspot|message","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"update_started","field_type":"dimension","group":"CLI","slug":"hubspot|update_started","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"update_id","field_type":"dimension","group":"CLI","slug":"hubspot|update_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"schema","field_type":"dimension","group":"CLI","slug":"hubspot|schema","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"table","field_type":"dimension","group":"CLI","slug":"hubspot|table","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"start","field_type":"dimension","group":"CLI","slug":"hubspot|start","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"done","field_type":"dimension","group":"CLI","slug":"hubspot|done","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"rows_updated_or_inserted","field_type":"metric","group":"CLI","slug":"hubspot|rows_updated_or_inserted","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"fivetran_audit_status","field_type":"dimension","group":"CLI","slug":"hubspot|fivetran_audit_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"progress","field_type":"dimension","group":"CLI","slug":"hubspot|progress","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_format":null,"display_name":"Last
-        Activity","field_type":"dimension","group":"CLI","slug":"hubspot|metadata_last_processing_state_change_at","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"concat(adwords|headline_1,\"
-        \" ,\"|\",\" \",adwords|headline_2  )","data_type":"text","description":"Combination
-        of Google Ads Headline 1 and Headline 2 field","display_format":"decimal_2","display_name":"Google
-        Ads Headline Concatenation ","field_type":"dimension","group":"Custom","slug":"google_ads_headline_concatenation","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"checkout_initiated
-        ","data_type":"numeric","description":"Showtime lookup click","display_format":"decimal_0","display_name":"Showtime
-        Lookup","field_type":"metric","group":"Custom","slug":"showtime_lookup","taxon_type":"metric"},{"aggregation":{"type":"avg"},"aggregation_type":"avg","calculation":"spend
-        /panoramic_z5y1clyi__leads_custom ","data_type":"money","description":"Cost
-        per Lead (Lead forms submitted on Pano Landing Page)","display_format":"usd_2","display_name":"CPL
-        (Pano LP)","field_type":"metric","group":"Custom","slug":"cpl_pano_lp","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"parse(merge(?facebook_ads|ad_name,?appnexus|creative_name,?linkedin|creative_id),\"_\",4)","data_type":"text","description":"DNU
-        TEST","display_format":"decimal_2","display_name":"Pano Ad Name 2","field_type":"dimension","group":"Custom","slug":"pano_ad_name_2","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"upper(parse(adwords|campaign_name,\"-\",2))","data_type":"text","description":"Parse.
-        Google Search Only. Campaign type (e.g. Branded or Non Branded) parsed from
-        the naming convention.","display_format":"decimal_2","display_name":"Campaign
-        Type (Part 1)","field_type":"dimension","group":"Custom","slug":"campaign_type","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"parse(adwords|campaign_name,\"-\",4)","data_type":"text","description":"Parse.
-        Google Search Only. Targeted non-brand terms parsed from the naming convention.","display_format":"decimal_2","display_name":"Targeting","field_type":"dimension","group":"Custom","slug":"targeting_1","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_would_you_like_to_see_a_demo_","field_type":"dimension","group":"CLI","slug":"hubspot|property_would_you_like_to_see_a_demo_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_where_are_you_spending_the_majority_your_time_","field_type":"dimension","group":"CLI","slug":"hubspot|property_where_are_you_spending_the_majority_your_time_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_magic_wand","field_type":"dimension","group":"CLI","slug":"hubspot|property_magic_wand","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_if_you_had_a_magic_wand_how_would_you_empower_your_marketing_and_analytics_teams_today_","field_type":"dimension","group":"CLI","slug":"hubspot|property_if_you_had_a_magic_wand_how_would_you_empower_your_marketing_and_analytics_teams_today_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_how_long_does_it_take_your_team_to_group_map_and_model_your_data_","field_type":"dimension","group":"CLI","slug":"hubspot|property_how_long_does_it_take_your_team_to_group_map_and_model_your_data_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_how_do_you_currently_collect_and_store_your_marketing_data_","field_type":"dimension","group":"CLI","slug":"hubspot|property_how_do_you_currently_collect_and_store_your_marketing_data_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_how_do_you_currently_collect_and_store_marketing_data_","field_type":"dimension","group":"CLI","slug":"hubspot|property_how_do_you_currently_collect_and_store_marketing_data_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_lifecyclestage_customer_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_lifecyclestage_customer_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_email_customer_quarantined_reason","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_customer_quarantined_reason","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_sales_email_last_clicked","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_sales_email_last_clicked","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_job_role","field_type":"dimension","group":"CLI","slug":"hubspot|property_job_role","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_title","field_type":"dimension","group":"CLI","slug":"hubspot|property_title","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_lifecyclestage_salesqualifiedlead_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_lifecyclestage_salesqualifiedlead_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_lifecyclestage_marketingqualifiedlead_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_lifecyclestage_marketingqualifiedlead_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_panoramic_lifecycle_stage","field_type":"dimension","group":"CLI","slug":"hubspot|property_panoramic_lifecycle_stage","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_what_industry_do_you_work_in","field_type":"dimension","group":"CLI","slug":"hubspot|property_what_industry_do_you_work_in","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_what_is_your_job_title","field_type":"dimension","group":"CLI","slug":"hubspot|property_what_is_your_job_title","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_what_is_your_job_role","field_type":"dimension","group":"CLI","slug":"hubspot|property_what_is_your_job_role","taxon_type":"dimension"},{"aggregation":{"type":"avg"},"aggregation_type":"avg","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_format":"decimal_0","display_name":"Implicit
-        Score","field_type":"metric","group":"CLI","slug":"hubspot|property_implicit_score","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_format":"decimal_2","display_name":"Explicit
-        Score","field_type":"metric","group":"CLI","slug":"hubspot|property_contact_score","taxon_type":"metric"},{"aggregation":{"type":"avg"},"aggregation_type":"avg","calculation":"panoramic_z5y1clyi__leads_custom
-        /panoramic_z5y1clyi__clicks_to_lp ","data_type":"percent","description":"Total
-        Lead Forms Submitted divided by Total Clicks to Landing Page","display_format":"percent_2","display_name":"Lead
-        Rate (Clicks to LP)","field_type":"metric","group":"Custom","slug":"lead_rate_clicks_to_lp","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"merge(?facebook_ads|ad_name,?appnexus|creative_name,?linkedin|creative_id)","data_type":"text","description":"Custom
-        Pano Ad Name Blending across Platforms","display_format":"decimal_2","display_name":"Pano
-        Ad Name","field_type":"dimension","group":"Custom","slug":"pano_ad_name","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"parse(panoramic_z5y1clyi__pano_ad_name
-        , ''_'', 6)","data_type":"text","description":"Parsed: Landing Page from Pano
-        Ad Name","display_format":"decimal_2","display_name":"Ad Landing Page","field_type":"dimension","group":"Custom","slug":"ad_landing_page","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"checkout_initiated
-        + twitter|conversion_purchases_metric + snapchat|conversion_purchases + conversions","data_type":"numeric","description":"Sacha''s
-        Conversions (twitter, snap, FB)","display_format":"decimal_0","display_name":"Sacha''s
-        Conversions","field_type":"metric","group":"Custom","slug":"sacha_s_conversions","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"parse(panoramic_z5y1clyi__pano_ad_name,\"_\",4)","data_type":"text","description":"Parsed:
-        Creative Name from Pano Ad Name","display_format":"decimal_2","display_name":"Creative
-        Name","field_type":"dimension","group":"Custom","slug":"creative_name","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"upper(parse(adwords|campaign_name,\"-\",3))","data_type":"text","description":"Google
-        Search Only. Campaign type (e.g. Branded or Non Branded) parsed from the naming
-        convention.","display_format":"decimal_2","display_name":"Campaign Type (Part
-        2)","field_type":"dimension","group":"Custom","slug":"targeting","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"merge(?facebook_ads|platform_position,?linkedin|campaign_type,?adwords|ad_group_type,?appnexus|creative_type)","data_type":"text","description":"Pano
-        custom blending of Ad Placement and Type","display_format":"decimal_2","display_name":"Placement/Type","field_type":"dimension","group":"Custom","slug":"ad_placement_type","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"panoramic_z5y1clyi_v_d_s_hubspot|property_implicit_score
-        + panoramic_z5y1clyi_v_d_s_hubspot|property_contact_score ","data_type":"numeric","description":null,"display_format":"decimal_2","display_name":"MQL","field_type":"metric","group":"Custom","slug":"mql","taxon_type":"metric"}]}
-
-        '
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '28110'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Nov 2020 15:10:21 GMT
-      Via:
-      - kong/2.0.3
-      X-Amzn-Trace-Id:
-      - None
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '265'
-      x-diesel-request-id:
-      - bfe1072c-b8d7-47e1-ace2-b3f66dc7f784
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - pano-cli/1.2.0
-    method: GET
-    uri: https://diesel.panoramicapi.com/api/v1/federated/taxonomy/taxons?company_slug=panoramic-z5y1clyi&offset=600&limit=100
-  response:
-    body:
-      string: '{"data":[{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"sumiff(objective_normalized
-        == \"Video Views\" ,impressions_viewed , 0)","data_type":"numeric","description":null,"display_format":"decimal_2","display_name":"Max''s
-        Viewable Impressions","field_type":"metric","group":"Custom","slug":"max_s_viewable_impressions","taxon_type":"metric"}]}
-
-        '
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '366'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Nov 2020 15:10:22 GMT
-      Via:
-      - kong/2.0.3
-      X-Amzn-Trace-Id:
-      - None
-      X-Kong-Proxy-Latency:
-      - '0'
-      X-Kong-Upstream-Latency:
-      - '32'
-      x-diesel-request-id:
-      - 64d1803d-84a6-4053-8cd1-a141f592a38d
+      - af584d75-c22e-489a-b265-776021182573
     status:
       code: 200
       message: OK
@@ -617,7 +271,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded;charset=UTF-8
       User-Agent:
-      - pano-cli/1.2.0
+      - pano-cli/1.4.0
     method: POST
     uri: https://id.panoramichq.com/oauth2/auscsj124wDoFObOJ4x6/v1/token
   response:
@@ -630,7 +284,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 02 Nov 2020 15:10:23 GMT
+      - Fri, 20 Nov 2020 11:28:47 GMT
       Keep-Alive:
       - timeout=5, max=100
       Server:
@@ -651,17 +305,17 @@ interactions:
       - no-cache
       set-cookie:
       - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
-      - JSESSIONID=668AD4C00A8321A6F918C8EFA4159A4B; Path=/; Secure; HttpOnly
+      - JSESSIONID=921E23E70DE24FBAC1AAD13AD4F95CA3; Path=/; Secure; HttpOnly
       x-content-type-options:
       - nosniff
       x-okta-request-id:
-      - X6AhXyS-JFVMJHX5YCa-jQAAAOc
+      - X7eob8Mi408yi4Bhx1-dMQAABc0
       x-rate-limit-limit:
       - '1200'
       x-rate-limit-remaining:
-      - '1197'
+      - '1186'
       x-rate-limit-reset:
-      - '1604329873'
+      - '1605871743'
       x-xss-protection:
       - '0'
     status:
@@ -681,23 +335,23 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - pano-cli/1.2.0
+      - pano-cli/1.4.0
     method: PUT
-    uri: https://diesel.panoramicapi.com/api/v1/federated/virtual-data-source?company_slug=panoramic-z5y1clyi
+    uri: https://diesel.panoramicapi.com/api/v1/federated/virtual-data-source?company_slug=panoramic-cli-e2e-c2m6qp4u
   response:
     body:
-      string: '{"data":{"display_name":"Test Dataset","global_slug":"panoramic_z5y1clyi_v_d_s_test_dataset","slug":"test_dataset"}}
+      string: '{"data":{"display_name":"Test Dataset","global_slug":"panoramic_cli_e2e_c2m6qp4u_v_d_s_test_dataset","slug":"test_dataset"}}
 
         '
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '117'
+      - '125'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Nov 2020 15:10:24 GMT
+      - Fri, 20 Nov 2020 11:28:47 GMT
       Via:
       - kong/2.0.3
       X-Amzn-Trace-Id:
@@ -705,9 +359,9 @@ interactions:
       X-Kong-Proxy-Latency:
       - '1'
       X-Kong-Upstream-Latency:
-      - '35'
+      - '61'
       x-diesel-request-id:
-      - 3c63c8ce-8b4b-47e5-ae1c-bdcc6db14ff0
+      - 037f83c8-d8d1-4661-9b95-893515e27a21
     status:
       code: 201
       message: CREATED
@@ -725,7 +379,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded;charset=UTF-8
       User-Agent:
-      - pano-cli/1.2.0
+      - pano-cli/1.4.0
     method: POST
     uri: https://id.panoramichq.com/oauth2/auscsj124wDoFObOJ4x6/v1/token
   response:
@@ -738,7 +392,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 02 Nov 2020 15:10:26 GMT
+      - Fri, 20 Nov 2020 11:28:48 GMT
       Keep-Alive:
       - timeout=5, max=100
       Server:
@@ -759,27 +413,28 @@ interactions:
       - no-cache
       set-cookie:
       - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
-      - JSESSIONID=AD1BE3A84BDFBA0D2B6939BDF7327DF7; Path=/; Secure; HttpOnly
+      - JSESSIONID=2473D7EA0ABCA6766FE08FB0600E0C38; Path=/; Secure; HttpOnly
       x-content-type-options:
       - nosniff
       x-okta-request-id:
-      - X6AhYfEe9HipqoTUoAuHJQAACa8
+      - X7eocMMi408yi4Bhx1-dMgAABbM
       x-rate-limit-limit:
       - '1200'
       x-rate-limit-remaining:
-      - '1196'
+      - '1185'
       x-rate-limit-reset:
-      - '1604329873'
+      - '1605871743'
       x-xss-protection:
       - '0'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"model_name": "test_model", "data_source": "pano_snowflake_66.snowflake_sample_data.tpch_sf1.nation",
-      "fields": [{"field_map": ["name"], "data_reference": "\"N_NAME\""}], "joins":
-      [{"to_model": "other_model", "join_type": "left", "relationship": "many_to_one",
-      "fields": ["name"]}], "identifiers": ["name"], "visibility": "available"}'
+    body: '{"model_name": "test_model", "data_source": "pano_snowflake_panoramic_cli_e_2_e_c_2_m_6_qp_4_u.snowflake_sample_data.tpch_sf1.nation",
+      "fields": [{"field_map": ["dataset_test_field"], "data_reference": "\"N_NAME\""}],
+      "joins": [{"to_model": "other_model", "join_type": "left", "relationship": "many_to_one",
+      "fields": ["dataset_test_field"]}], "identifiers": ["dataset_test_field"], "visibility":
+      "available"}'
     headers:
       Accept:
       - '*/*'
@@ -788,13 +443,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '335'
+      - '409'
       Content-Type:
       - application/json
       User-Agent:
-      - pano-cli/1.2.0
+      - pano-cli/1.4.0
     method: PUT
-    uri: https://diesel.panoramicapi.com/api/v1/federated/model/?virtual_data_source=test_dataset&company_slug=panoramic-z5y1clyi&create_fields=true
+    uri: https://diesel.panoramicapi.com/api/v1/federated/model/?virtual_data_source=test_dataset&company_slug=panoramic-cli-e2e-c2m6qp4u
   response:
     body:
       string: ''
@@ -804,7 +459,120 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Mon, 02 Nov 2020 15:10:27 GMT
+      - Fri, 20 Nov 2020 11:28:49 GMT
+      Via:
+      - kong/2.0.3
+      X-Amzn-Trace-Id:
+      - None
+      X-Kong-Proxy-Latency:
+      - '1'
+      X-Kong-Upstream-Latency:
+      - '318'
+      x-diesel-request-id:
+      - bd3a534d-06a1-4cb3-a99b-c69d619cfb87
+    status:
+      code: 204
+      message: NO CONTENT
+- request:
+    body: grant_type=client_credentials&scope=platform
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      User-Agent:
+      - pano-cli/1.4.0
+    method: POST
+    uri: https://id.panoramichq.com/oauth2/auscsj124wDoFObOJ4x6/v1/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": 3600, "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+        "scope": "platform"}'
+    headers:
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Fri, 20 Nov 2020 11:28:49 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      cache-control:
+      - no-cache, no-store
+      expires:
+      - '0'
+      p3p:
+      - CP="HONK"
+      pragma:
+      - no-cache
+      set-cookie:
+      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      - JSESSIONID=98F1E6137DCBCE364F9BBD29C14B17A4; Path=/; Secure; HttpOnly
+      x-content-type-options:
+      - nosniff
+      x-okta-request-id:
+      - X7eocVdVotJXe8R3MDDMiwAABZ8
+      x-rate-limit-limit:
+      - '1200'
+      x-rate-limit-remaining:
+      - '1184'
+      x-rate-limit-reset:
+      - '1605871743'
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '[{"slug": "company_test_field", "group": "Custom", "display_name": "Company
+      test field", "data_type": "text", "field_type": "dimension", "description":
+      null, "calculation": "2 + 2", "aggregation": {"type": "group_by"}, "data_source":
+      null, "display_format": null}]'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '264'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - pano-cli/1.4.0
+    method: POST
+    uri: https://diesel.panoramicapi.com/api/v1/federated/taxonomy/taxons?company_slug=panoramic-cli-e2e-c2m6qp4u
+  response:
+    body:
+      string: '{"data":[{"acronym":null,"aggregation":{"type":"group_by"},"calculation":"2
+        + 2","data_type":"text","description":null,"display_format":null,"display_name":"Company
+        test field","field_type":"dimension","group":"Custom","slug":"company_test_field","validation_type":"text"}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '275'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Nov 2020 11:28:50 GMT
       Via:
       - kong/2.0.3
       X-Amzn-Trace-Id:
@@ -812,12 +580,60 @@ interactions:
       X-Kong-Proxy-Latency:
       - '0'
       X-Kong-Upstream-Latency:
-      - '88'
+      - '255'
       x-diesel-request-id:
-      - 2fad5a57-c03e-4117-97c1-5d11a8a69227
+      - 0479286c-89cc-46d9-b7dc-968c57d84b03
     status:
-      code: 204
-      message: NO CONTENT
+      code: 200
+      message: OK
+- request:
+    body: '[{"slug": "test_dataset|dataset_test_field", "group": "Custom", "display_name":
+      "Dataset test field", "data_type": "text", "field_type": "metric", "description":
+      null, "calculation": null, "aggregation": {"type": "sum"}, "data_source": "test_dataset",
+      "display_format": null}]'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '276'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - pano-cli/1.4.0
+    method: POST
+    uri: https://diesel.panoramicapi.com/api/v1/federated/taxonomy/taxons?company_slug=panoramic-cli-e2e-c2m6qp4u
+  response:
+    body:
+      string: '{"data":[{"acronym":null,"aggregation":{"type":"sum"},"calculation":null,"data_source":"test_dataset","data_type":"text","description":null,"display_format":null,"display_name":"Dataset
+        test field","field_type":"metric","group":"Custom","slug":"test_dataset|dataset_test_field","validation_type":"text"}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '306'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Nov 2020 11:28:50 GMT
+      Via:
+      - kong/2.0.3
+      X-Amzn-Trace-Id:
+      - None
+      X-Kong-Proxy-Latency:
+      - '1'
+      X-Kong-Upstream-Latency:
+      - '345'
+      x-diesel-request-id:
+      - 709e7b92-bbb0-4b70-9eff-ed2a647b9b30
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
@@ -828,19 +644,17 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - pano-cli/1.2.0
+      - pano-cli/1.4.0
     method: GET
     uri: https://a1.panocdn.com/updates/pano-cli/versions.json
   response:
     body:
-      string: '{"minimum_supported_version": "1.0.0", "latest_version": "1.2.0"}'
+      string: '{"minimum_supported_version": "1.3.1", "latest_version": "1.3.3"}'
     headers:
       Accept-Ranges:
       - bytes
       Age:
-      - '56'
-      Cache-Control:
-      - max-age=60
+      - '6261'
       Connection:
       - keep-alive
       Content-Length:
@@ -848,17 +662,17 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Nov 2020 15:10:12 GMT
+      - Fri, 20 Nov 2020 09:44:31 GMT
       ETag:
-      - '"b567ca5ec4a1c3c27497963ad975f8f5"'
+      - '"27c3611f3cf23f5e138de084cc76d1b7"'
       Last-Modified:
-      - Fri, 30 Oct 2020 21:22:49 GMT
+      - Wed, 18 Nov 2020 13:00:30 GMT
       Server:
       - AmazonS3
       Via:
-      - 1.1 b051e9c33308597b659c33b8999b521d.cloudfront.net (CloudFront)
+      - 1.1 a97d638d4e395a6f27b927572cf3bfda.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - w3wdbGb8pLPt1U0sQcCSEZCwa-EXY-oTlcUjY7jrW2InvYYN5CxG7A==
+      - fDnYjxcWAVXxrUzXLaD0iX8EDnkmVsyODPzxiHUgbFbusOGsOvoT8g==
       X-Amz-Cf-Pop:
       - IAD89-C2
       X-Cache:
@@ -866,7 +680,7 @@ interactions:
       x-amz-replication-status:
       - COMPLETED
       x-amz-version-id:
-      - 7gL4L94FhP5vViOT0_j0Ees.dSesIhqr
+      - mG5i_duZYt9G0wN9uH2LFIW2WoQ756Fc
     status:
       code: 200
       message: OK
@@ -884,7 +698,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded;charset=UTF-8
       User-Agent:
-      - pano-cli/1.2.0
+      - pano-cli/1.4.0
     method: POST
     uri: https://id.panoramichq.com/oauth2/auscsj124wDoFObOJ4x6/v1/token
   response:
@@ -897,7 +711,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 02 Nov 2020 15:11:08 GMT
+      - Fri, 20 Nov 2020 11:28:51 GMT
       Keep-Alive:
       - timeout=5, max=100
       Server:
@@ -918,17 +732,17 @@ interactions:
       - no-cache
       set-cookie:
       - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
-      - JSESSIONID=1C64401C12BA72101830EBCE1F976A1F; Path=/; Secure; HttpOnly
+      - JSESSIONID=30D319682953ACCDF4C8481D8B826858; Path=/; Secure; HttpOnly
       x-content-type-options:
       - nosniff
       x-okta-request-id:
-      - X6AhjO72HBYZdJSPJDjfSQAABA4
+      - X7eoc-JnXkxYWR-cV6EBQQAAAEE
       x-rate-limit-limit:
       - '1200'
       x-rate-limit-remaining:
-      - '1195'
+      - '1183'
       x-rate-limit-reset:
-      - '1604329873'
+      - '1605871743'
       x-xss-protection:
       - '0'
     status:
@@ -944,731 +758,23 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - pano-cli/1.2.0
+      - pano-cli/1.4.0
     method: GET
-    uri: https://diesel.panoramicapi.com/api/v1/federated/virtual-data-source?company_slug=panoramic-z5y1clyi&offset=0&limit=100
+    uri: https://diesel.panoramicapi.com/api/v1/federated/virtual-data-source?company_slug=panoramic-cli-e2e-c2m6qp4u&offset=0&limit=100
   response:
     body:
-      string: '{"data":[{"display_name":"Test Dataset","global_slug":"panoramic_z5y1clyi_v_d_s_test_dataset","slug":"test_dataset"}]}
+      string: '{"data":[{"display_name":"Test Dataset","global_slug":"panoramic_cli_e2e_c2m6qp4u_v_d_s_test_dataset","slug":"test_dataset"}]}
 
         '
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '119'
+      - '127'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Nov 2020 15:11:09 GMT
-      Via:
-      - kong/2.0.3
-      X-Amzn-Trace-Id:
-      - None
-      X-Kong-Proxy-Latency:
-      - '0'
-      X-Kong-Upstream-Latency:
-      - '66'
-      x-diesel-request-id:
-      - 44c520a1-c70e-4e81-8f61-bfd18690f874
-    status:
-      code: 200
-      message: OK
-- request:
-    body: grant_type=client_credentials&scope=platform
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      Content-Type:
-      - application/x-www-form-urlencoded;charset=UTF-8
-      User-Agent:
-      - pano-cli/1.2.0
-    method: POST
-    uri: https://id.panoramichq.com/oauth2/auscsj124wDoFObOJ4x6/v1/token
-  response:
-    body:
-      string: '{"token_type": "Bearer", "expires_in": 3600, "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
-        "scope": "platform"}'
-    headers:
-      Connection:
-      - Keep-Alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Mon, 02 Nov 2020 15:11:10 GMT
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=315360000; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      X-Robots-Tag:
-      - none
-      cache-control:
-      - no-cache, no-store
-      expires:
-      - '0'
-      p3p:
-      - CP="HONK"
-      pragma:
-      - no-cache
-      set-cookie:
-      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
-      - JSESSIONID=A0AB360DA26A1DAC009686F43111CDD7; Path=/; Secure; HttpOnly
-      x-content-type-options:
-      - nosniff
-      x-okta-request-id:
-      - X6AhjmV1XMX6n51K3EKhtgAAA-k
-      x-rate-limit-limit:
-      - '1200'
-      x-rate-limit-remaining:
-      - '1194'
-      x-rate-limit-reset:
-      - '1604329873'
-      x-xss-protection:
-      - '0'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - pano-cli/1.2.0
-    method: GET
-    uri: https://diesel.panoramicapi.com/api/v1/federated/model/?virtual_data_source=test_dataset&company_slug=panoramic-z5y1clyi&offset=0&limit=100
-  response:
-    body:
-      string: '{"data":[{"data_source":"pano_snowflake_66.snowflake_sample_data.tpch_sf1.nation","fields":[{"data_reference":"\"N_NAME\"","data_type":null,"field_map":["name"]}],"identifiers":["name"],"joins":[{"fields":["name"],"join_type":"left","relationship":"many_to_one","to_model":"other_model"}],"model_name":"test_model","visibility":"available"}]}
-
-        '
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '343'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Nov 2020 15:11:11 GMT
-      Via:
-      - kong/2.0.3
-      X-Amzn-Trace-Id:
-      - None
-      X-Kong-Proxy-Latency:
-      - '0'
-      X-Kong-Upstream-Latency:
-      - '406'
-      x-diesel-request-id:
-      - cff2f9f9-6058-466a-9585-0abdccd05f30
-    status:
-      code: 200
-      message: OK
-- request:
-    body: grant_type=client_credentials&scope=platform
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      Content-Type:
-      - application/x-www-form-urlencoded;charset=UTF-8
-      User-Agent:
-      - pano-cli/1.2.0
-    method: POST
-    uri: https://id.panoramichq.com/oauth2/auscsj124wDoFObOJ4x6/v1/token
-  response:
-    body:
-      string: '{"token_type": "Bearer", "expires_in": 3600, "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
-        "scope": "platform"}'
-    headers:
-      Connection:
-      - Keep-Alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Mon, 02 Nov 2020 15:11:13 GMT
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=315360000; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      X-Robots-Tag:
-      - none
-      cache-control:
-      - no-cache, no-store
-      expires:
-      - '0'
-      p3p:
-      - CP="HONK"
-      pragma:
-      - no-cache
-      set-cookie:
-      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
-      - JSESSIONID=4E41B4B182833E428BF70F53E45FF189; Path=/; Secure; HttpOnly
-      x-content-type-options:
-      - nosniff
-      x-okta-request-id:
-      - X6AhkIkTJOsrUdvdv1EwfwAAAyY
-      x-rate-limit-limit:
-      - '1200'
-      x-rate-limit-remaining:
-      - '1193'
-      x-rate-limit-reset:
-      - '1604329873'
-      x-xss-protection:
-      - '0'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - pano-cli/1.2.0
-    method: GET
-    uri: https://diesel.panoramicapi.com/api/v1/federated/taxonomy/taxons?company_slug=panoramic-z5y1clyi&offset=0&limit=100
-  response:
-    body:
-      string: '{"data":[{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_type":"numeric","description":"How
-        much of the expected value has been delivered to the customer","display_name":"Delivery","field_type":"metric","group":"Custom","slug":"delivery","taxon_type":"metric"},{"calculation":null,"data_type":"text","description":null,"display_name":"Health
-        Score Date","field_type":"dimension","group":"Custom","slug":"health_score_date","taxon_type":"dimension"},{"calculation":null,"data_type":"text","description":"Name
-        of Client","display_name":"Account Name","field_type":"dimension","group":"Custom","slug":"account_name","taxon_type":"dimension"},{"calculation":null,"data_type":"text","description":null,"display_name":"Grade","field_type":"dimension","group":"Custom","slug":"grade_1","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_type":"numeric","description":"How
-        the customer feels about the platform","display_name":"Sentiment","field_type":"metric","group":"Custom","slug":"sentiment","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_type":"text","description":null,"display_format":"decimal_2","display_name":"Platform
-        - Pano Test","field_type":"dimension","group":"Custom","slug":"platform_pano_test","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_type":"numeric","description":"Ho
-        much the client is engaged with the platform","display_name":"Usage","field_type":"metric","group":"Custom","slug":"usage","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"contact_list_id","field_type":"metric","group":"CLI","slug":"hubspot|contact_list_id","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"contact_id","field_type":"metric","group":"CLI","slug":"hubspot|contact_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"added_at","field_type":"dimension","group":"CLI","slug":"hubspot|added_at","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_event_delivered_id","field_type":"dimension","group":"CLI","slug":"hubspot|email_event_delivered_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"smtp_id","field_type":"dimension","group":"CLI","slug":"hubspot|smtp_id","taxon_type":"dimension"},{"aggregation":{"type":"avg"},"aggregation_type":"avg","calculation":null,"data_type":"money","description":"Max
-        is testing","display_name":"Max''s CPA","field_type":"metric","group":"Custom","slug":"my_cpa","taxon_type":"metric"},{"calculation":null,"data_type":"text","description":"A
-        conversion is a click on the \"download\" button (traffic to a landing page),
-        so not a true conversion","display_name":"Conversion - LinkedIn","field_type":"dimension","group":"Custom","slug":"conversion_linked_in","taxon_type":"dimension"},{"calculation":null,"data_type":"text","description":"An
-        aggregated and anonymized dataset used for comparison respective to whichever
-        Dimensions (e.g. Objective, Publisher, Age, Country, etc.) have been applied
-        in the platform.","display_name":"Benchmark","field_type":"dimension","group":"Custom","slug":"benchmark","taxon_type":"dimension"},{"calculation":null,"data_type":"text","description":null,"display_format":null,"display_name":"Company
-        test field","field_type":"dimension","group":"Custom","slug":"company_test_field","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"is_deleted","field_type":"dimension","group":"CLI","slug":"hubspot|is_deleted","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_businessunity_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_businessunity_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_analytics_engineer_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_analytics_engineer_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_analytics_source_data_2","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_source_data_2","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_analytics_source_data_1","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_source_data_1","taxon_type":"dimension"},{"calculation":null,"data_source":"test_dataset","data_type":"text","description":null,"display_format":null,"display_name":"Dataset
-        test field","field_type":"metric","group":"Custom","slug":"test_dataset|dataset_test_field","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"
-        (panoramic_z5y1clyi__usage*3)+(2*panoramic_z5y1clyi__delivery)+(panoramic_z5y1clyi__sentiment*5)","data_type":"numeric","description":"Weighted
-        Score","display_name":"Total Score","field_type":"metric","group":"Custom","slug":"total_score","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"merge(?facebook_ads|campaign_name,?linkedin|campaign_group_name)","data_type":"text","description":"Campaign
-        Naming Convention (Social)","display_format":"decimal_2","display_name":"Pano
-        Campaign Name","field_type":"dimension","group":"Custom","slug":"pano_campaign_name","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"?
-        facebook_ads|actions__offsite_conversion_fb_pixel_lead_value + ?facebook_ads|actions__onsite_conversion__lead_grouped_value  +
-        ?adwords|conversions_purchase + ?linkedin|external_website_conversions + ?appnexus|total_convs
-        ","data_type":"numeric","description":null,"display_format":"decimal_0","display_name":"GH
-        Test","field_type":"metric","group":"Custom","slug":"gh_test","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"merge(?facebook_ads|adset_name,?linkedin|campaign_name)","data_type":"text","description":"Pano
-        Ad Set Name used for Parsing Naming Covention","display_format":"decimal_2","display_name":"Pano
-        Adgroup Name","field_type":"dimension","group":"Custom","slug":"pano_ad_set_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"engagement_type","field_type":"dimension","group":"CLI","slug":"hubspot|engagement_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"activity_type","field_type":"dimension","group":"CLI","slug":"hubspot|activity_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"engagement_last_updated","field_type":"dimension","group":"CLI","slug":"hubspot|engagement_last_updated","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"guid","field_type":"dimension","group":"CLI","slug":"hubspot|guid","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"portal_id","field_type":"metric","group":"CLI","slug":"hubspot|portal_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"form_name","field_type":"dimension","group":"CLI","slug":"hubspot|form_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"action","field_type":"dimension","group":"CLI","slug":"hubspot|action","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"method","field_type":"dimension","group":"CLI","slug":"hubspot|method","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"css_class","field_type":"dimension","group":"CLI","slug":"hubspot|css_class","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"to_number","field_type":"dimension","group":"CLI","slug":"hubspot|to_number","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"from_number","field_type":"dimension","group":"CLI","slug":"hubspot|from_number","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"engagement_call_status","field_type":"dimension","group":"CLI","slug":"hubspot|engagement_call_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"external_id","field_type":"dimension","group":"CLI","slug":"hubspot|external_id","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"duration_milliseconds","field_type":"metric","group":"CLI","slug":"hubspot|duration_milliseconds","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"external_account_id","field_type":"dimension","group":"CLI","slug":"hubspot|external_account_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"recording_url","field_type":"dimension","group":"CLI","slug":"hubspot|recording_url","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"disposition","field_type":"dimension","group":"CLI","slug":"hubspot|disposition","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"callee_object_type","field_type":"dimension","group":"CLI","slug":"hubspot|callee_object_type","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"callee_object_id","field_type":"metric","group":"CLI","slug":"hubspot|callee_object_id","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"transcription_id","field_type":"metric","group":"CLI","slug":"hubspot|transcription_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_email","field_type":"dimension","group":"CLI","slug":"hubspot|property_email","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"change","field_type":"dimension","group":"CLI","slug":"hubspot|change","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"change_type","field_type":"dimension","group":"CLI","slug":"hubspot|change_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"caused_by_event_id","field_type":"dimension","group":"CLI","slug":"hubspot|caused_by_event_id","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"email_subscription_id","field_type":"metric","group":"CLI","slug":"hubspot|email_subscription_id","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"parse(panoramic_z5y1clyi__pano_campaign_name
-        , ''_'', 4)","data_type":"text","description":"Parsed: Campaign Audience Type
-        from Pano Campaign Name","display_format":"decimal_2","display_name":"Campaign
-        Audience Type","field_type":"dimension","group":"Custom","slug":"campaign_audience_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"app_name","field_type":"dimension","group":"CLI","slug":"hubspot|app_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_campaign_name","field_type":"dimension","group":"CLI","slug":"hubspot|email_campaign_name","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"num_included","field_type":"metric","group":"CLI","slug":"hubspot|num_included","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"num_queued","field_type":"metric","group":"CLI","slug":"hubspot|num_queued","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"sub_type","field_type":"dimension","group":"CLI","slug":"hubspot|sub_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_campaign_type","field_type":"dimension","group":"CLI","slug":"hubspot|email_campaign_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"calendar_event_id","field_type":"dimension","group":"CLI","slug":"hubspot|calendar_event_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"event_type","field_type":"dimension","group":"CLI","slug":"hubspot|event_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"event_date","field_type":"dimension","group":"CLI","slug":"hubspot|event_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"category","field_type":"dimension","group":"CLI","slug":"hubspot|category","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"category_id","field_type":"metric","group":"CLI","slug":"hubspot|category_id","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"content_id","field_type":"metric","group":"CLI","slug":"hubspot|content_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"state","field_type":"dimension","group":"CLI","slug":"hubspot|state","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_event_click_id","field_type":"dimension","group":"CLI","slug":"hubspot|email_event_click_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"ip_address","field_type":"dimension","group":"CLI","slug":"hubspot|ip_address","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"user_agent","field_type":"dimension","group":"CLI","slug":"hubspot|user_agent","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_type":"text","description":"this
-        is sacha''s test","display_format":"decimal_2","display_name":"Sacha''s Dimension
-        Test","field_type":"dimension","group":"Custom","slug":"sacha_s_dimension_test","taxon_type":"dimension"},{"calculation":null,"data_type":"text","description":"Testing","display_format":null,"display_name":"Panoramic
-        test","field_type":"dimension","group":"Custom","slug":"panoramic_test","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"concat(panoramic_z5y1clyi__campaign_type,\"
-        \",panoramic_z5y1clyi__targeting)","data_type":"text","description":"Concat.
-        Google Search. Branded or Non-Branded Campaigns.","display_format":"decimal_2","display_name":"Campaign
-        Type","field_type":"dimension","group":"Custom","slug":"campaign_type_3","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"parse(panoramic_z5y1clyi__pano_ad_name
-        , ''_'',3)","data_type":"text","description":"Parsed: Creative Type from Pano
-        Ad Name","display_format":"decimal_2","display_name":"Creative Type","field_type":"dimension","group":"Custom","slug":"creative_type","taxon_type":"dimension"},{"aggregation":{"type":"avg"},"aggregation_type":"avg","calculation":"panoramic_z5y1clyi_v_d_s_hubspot|property_implicit_score
-        ","data_type":"numeric","description":"Average of Implicit Score","display_format":"decimal_0","display_name":"Implicit
-        Score (Avg)","field_type":"metric","group":"Custom","slug":"implicit_score_avg","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"merge(?facebook_ads|ad_name,?panoramic_z5y1clyi__google_ads_headline_concatenation,?appnexus|creative_name,?linkedin|creative_id)","data_type":"text","description":"DNU
-        Testing Ad Name Merge","display_format":"decimal_2","display_name":"DNU Ad
-        Name Merge","field_type":"dimension","group":"Custom","slug":"dnu_ad_name_merge","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"?adwords|conversions_purchase
-        + ?linkedin|external_website_conversions + ?appnexus|total_convs + ?facebook_ads|actions__offsite_conversion_fb_pixel_lead_value
-        + ?facebook_ads|actions__onsite_conversion__lead_grouped_value ","data_type":"numeric","description":"Total
-        Lead Forms Submitted on Pano Landing Page","display_format":"decimal_0","display_name":"Leads
-        (Pano LP)","field_type":"metric","group":"Custom","slug":"leads_custom","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"coalesce(panoramic_z5y1clyi__showtime_lookup_1
-        ,impressions )","data_type":"numeric","description":null,"display_format":"decimal_2","display_name":"KT
-        test DNU","field_type":"metric","group":"Custom","slug":"kt_test_dnu","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"vid","field_type":"dimension","group":"CLI","slug":"hubspot|vid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"saved_at_timestamp","field_type":"dimension","group":"CLI","slug":"hubspot|saved_at_timestamp","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"deleted_changed_timestamp","field_type":"dimension","group":"CLI","slug":"hubspot|deleted_changed_timestamp","taxon_type":"dimension"},{"aggregation":{"type":"avg"},"aggregation_type":"avg","calculation":"300*1","data_type":"money","description":"8/1/20
-        - 8/31/20 CPL (Pano LP) Goal","display_format":"usd_2","display_name":"GOAL:
-        CPL (Pano LP)","field_type":"metric","group":"Custom","slug":"cpl_goal","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"from_email","field_type":"dimension","group":"CLI","slug":"hubspot|from_email","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"from_first_name","field_type":"dimension","group":"CLI","slug":"hubspot|from_first_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"from_last_name","field_type":"dimension","group":"CLI","slug":"hubspot|from_last_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"subject","field_type":"dimension","group":"CLI","slug":"hubspot|subject","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"html","field_type":"dimension","group":"CLI","slug":"hubspot|html","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"text","field_type":"dimension","group":"CLI","slug":"hubspot|text","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"tracker_key","field_type":"dimension","group":"CLI","slug":"hubspot|tracker_key","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"message_id","field_type":"dimension","group":"CLI","slug":"hubspot|message_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"contact_list_name","field_type":"dimension","group":"CLI","slug":"hubspot|contact_list_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"deleteable","field_type":"dimension","group":"CLI","slug":"hubspot|deleteable","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"dynamic","field_type":"dimension","group":"CLI","slug":"hubspot|dynamic","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"metadata_processing","field_type":"dimension","group":"CLI","slug":"hubspot|metadata_processing","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"metadata_last_size_change_at","field_type":"dimension","group":"CLI","slug":"hubspot|metadata_last_size_change_at","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"metadata_error","field_type":"dimension","group":"CLI","slug":"hubspot|metadata_error","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"offset","field_type":"metric","group":"CLI","slug":"hubspot|offset","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_format":"decimal_0","display_name":"Size","field_type":"metric","group":"CLI","slug":"hubspot|metadata_size","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"parse(panoramic_z5y1clyi__pano_ad_set_name
-        , ''_'', 4)","data_type":"text","description":"Parsed: Ad Set Audience from
-        Pano Ad Set Name","display_format":"decimal_2","display_name":"Adgroup Audience","field_type":"dimension","group":"Custom","slug":"ad_set_audience","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"searches
-        ","data_type":"numeric","description":"Showtime Lookup","display_format":"decimal_2","display_name":"Showtime
-        Lookup","field_type":"metric","group":"Custom","slug":"showtime_lookup_1","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"?linkedin|landing_page_clicks
-        + ?adwords|clicks + ?facebook_ads|actions__link_click_value + ?appnexus|clicks
-        ","data_type":"numeric","description":"Total Clicks to Landing Page","display_format":"decimal_0","display_name":"Clicks
-        to LP","field_type":"metric","group":"Custom","slug":"clicks_to_lp","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"parse(panoramic_z5y1clyi__pano_campaign_name
-        , ''_'',  3)","data_type":"text","description":"Parsed: Campaign Audience
-        Group from Pano Naming Convention","display_format":"decimal_2","display_name":"Campaign
-        Audience Group","field_type":"dimension","group":"Custom","slug":"campaign_audience_group","taxon_type":"dimension"}]}
-
-        '
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '24902'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Nov 2020 15:11:14 GMT
-      Via:
-      - kong/2.0.3
-      X-Amzn-Trace-Id:
-      - None
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '75'
-      x-diesel-request-id:
-      - ee46af35-bebf-4bb1-88e6-53a48d498181
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - pano-cli/1.2.0
-    method: GET
-    uri: https://diesel.panoramicapi.com/api/v1/federated/taxonomy/taxons?company_slug=panoramic-z5y1clyi&offset=100&limit=100
-  response:
-    body:
-      string: '{"data":[{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"parse(panoramic_z5y1clyi__pano_ad_name
-        , ''_'', 5)","data_type":"text","description":"Parsed: Ad Text/Copy from Pano
-        Ad Name","display_format":"decimal_2","display_name":"Ad Text/Copy","field_type":"dimension","group":"Custom","slug":"ad_text_copy","taxon_type":"dimension"},{"aggregation":{"type":"avg"},"aggregation_type":"avg","calculation":"spend
-        / panoramic_z5y1clyi__clicks_to_lp ","data_type":"money","description":"Cost
-        per Landing Page Click","display_format":"usd_2","display_name":"CPC (LP)","field_type":"metric","group":"Custom","slug":"cpc_lp","taxon_type":"metric"},{"calculation":null,"data_type":"text","description":null,"display_format":null,"display_name":"Objective","field_type":"dimension","group":"Custom","slug":"objective","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"sumiff(data_source==\"facebook_ads\",30,sumiff(data_source==\"linkedin\",25,sumiff(data_source==\"adwords\",75)))","data_type":"numeric","description":"Data
-        Source Leads (Pano LP) Goal for 8/1-8/31","display_format":"decimal_0","display_name":"GOAL:
-        Leads (Pano LP)","field_type":"metric","group":"Custom","slug":"test_leads_goal","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"merge(facebook_ads|effective_status,adwords|campaign_state,linkedin|status,appnexus|campaign_state
-        )","data_type":"text","description":"Custom Field. The status of your campaign
-        - example statuses are pending, active, inactive, and ended.","display_format":"decimal_2","display_name":"Campaign
-        Status","field_type":"dimension","group":"Custom","slug":"campaign_status_pano","taxon_type":"dimension"},{"aggregation":{"type":"avg"},"aggregation_type":"avg","calculation":"5","data_type":"money","description":null,"display_format":"usd_2","display_name":"Max''s
-        Benchmark","field_type":"metric","group":"Custom","slug":"max_s_benchmark","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"contact_property_history_value","field_type":"dimension","group":"CLI","slug":"hubspot|contact_property_history_value","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_format":null,"display_name":"contact_property_history_name","field_type":"dimension","group":"CLI","slug":"hubspot|contact_property_history_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_event_id","field_type":"dimension","group":"CLI","slug":"hubspot|email_event_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"created","field_type":"dimension","group":"CLI","slug":"hubspot|created","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_event_type","field_type":"dimension","group":"CLI","slug":"hubspot|email_event_type","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"app_id","field_type":"metric","group":"CLI","slug":"hubspot|app_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"filtered_event","field_type":"dimension","group":"CLI","slug":"hubspot|filtered_event","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"email_campaign_id","field_type":"metric","group":"CLI","slug":"hubspot|email_campaign_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"sent_by_id","field_type":"dimension","group":"CLI","slug":"hubspot|sent_by_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"sent_by_created","field_type":"dimension","group":"CLI","slug":"hubspot|sent_by_created","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"caused_by_id","field_type":"dimension","group":"CLI","slug":"hubspot|caused_by_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"caused_by_created","field_type":"dimension","group":"CLI","slug":"hubspot|caused_by_created","taxon_type":"dimension"},{"aggregation":{"type":"avg"},"aggregation_type":"avg","calculation":"panoramic_z5y1clyi__clicks_to_lp
-        / impressions","data_type":"percent","description":"Click Through Rate to
-        Landing Page","display_format":"percent_2","display_name":"CTR (LP)","field_type":"metric","group":"Custom","slug":"lp_click_rate","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"engagement_id","field_type":"metric","group":"CLI","slug":"hubspot|engagement_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"body","field_type":"dimension","group":"CLI","slug":"hubspot|body","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"start_time","field_type":"dimension","group":"CLI","slug":"hubspot|start_time","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"end_time","field_type":"dimension","group":"CLI","slug":"hubspot|end_time","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"engagement_meeting_title","field_type":"dimension","group":"CLI","slug":"hubspot|engagement_meeting_title","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"external_url","field_type":"dimension","group":"CLI","slug":"hubspot|external_url","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"created_from_link_id","field_type":"metric","group":"CLI","slug":"hubspot|created_from_link_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"web_conference_meeting_id","field_type":"dimension","group":"CLI","slug":"hubspot|web_conference_meeting_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"pre_meeting_prospect_reminders","field_type":"dimension","group":"CLI","slug":"hubspot|pre_meeting_prospect_reminders","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_event_status_change_id","field_type":"dimension","group":"CLI","slug":"hubspot|email_event_status_change_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"requested_by","field_type":"dimension","group":"CLI","slug":"hubspot|requested_by","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"portal_subscription_status","field_type":"dimension","group":"CLI","slug":"hubspot|portal_subscription_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"subscriptions","field_type":"dimension","group":"CLI","slug":"hubspot|subscriptions","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"bounced","field_type":"dimension","group":"CLI","slug":"hubspot|bounced","taxon_type":"dimension"},{"calculation":null,"data_source":"test_dataset","data_type":"text","description":null,"display_name":"name","field_type":"dimension","group":"CLI","slug":"test_dataset|name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_event_open_id","field_type":"dimension","group":"CLI","slug":"hubspot|email_event_open_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"duration","field_type":"dimension","group":"CLI","slug":"hubspot|duration","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"redirect","field_type":"dimension","group":"CLI","slug":"hubspot|redirect","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"submit_text","field_type":"dimension","group":"CLI","slug":"hubspot|submit_text","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"follow_up_id","field_type":"dimension","group":"CLI","slug":"hubspot|follow_up_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"notify_recipients","field_type":"dimension","group":"CLI","slug":"hubspot|notify_recipients","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"lead_nurturing_campaign_id","field_type":"dimension","group":"CLI","slug":"hubspot|lead_nurturing_campaign_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"created_at","field_type":"dimension","group":"CLI","slug":"hubspot|created_at","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"updated_at","field_type":"dimension","group":"CLI","slug":"hubspot|updated_at","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"_fivetran_deleted","field_type":"dimension","group":"CLI","slug":"hubspot|_fivetran_deleted","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"_fivetran_synced","field_type":"dimension","group":"CLI","slug":"hubspot|_fivetran_synced","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_event_deferred_id","field_type":"dimension","group":"CLI","slug":"hubspot|email_event_deferred_id","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"attempt","field_type":"metric","group":"CLI","slug":"hubspot|attempt","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"pipeline_id","field_type":"dimension","group":"CLI","slug":"hubspot|pipeline_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"label","field_type":"dimension","group":"CLI","slug":"hubspot|label","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"active","field_type":"dimension","group":"CLI","slug":"hubspot|active","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"display_order","field_type":"metric","group":"CLI","slug":"hubspot|display_order","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"deal_id","field_type":"metric","group":"CLI","slug":"hubspot|deal_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"deal_property_history_name","field_type":"dimension","group":"CLI","slug":"hubspot|deal_property_history_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"timestamp","field_type":"dimension","group":"CLI","slug":"hubspot|timestamp","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"deal_property_history_value","field_type":"dimension","group":"CLI","slug":"hubspot|deal_property_history_value","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"source_id","field_type":"dimension","group":"CLI","slug":"hubspot|source_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"source","field_type":"dimension","group":"CLI","slug":"hubspot|source","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"identity_vid","field_type":"dimension","group":"CLI","slug":"hubspot|identity_vid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"identity_profile_identity_value","field_type":"dimension","group":"CLI","slug":"hubspot|identity_profile_identity_value","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"identity_profile_identity_type","field_type":"dimension","group":"CLI","slug":"hubspot|identity_profile_identity_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"is_primary","field_type":"dimension","group":"CLI","slug":"hubspot|is_primary","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"is_secondary","field_type":"dimension","group":"CLI","slug":"hubspot|is_secondary","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"conversion_id","field_type":"dimension","group":"CLI","slug":"hubspot|conversion_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"contact_form_submission_title","field_type":"dimension","group":"CLI","slug":"hubspot|contact_form_submission_title","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"form_id","field_type":"dimension","group":"CLI","slug":"hubspot|form_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"page_url","field_type":"dimension","group":"CLI","slug":"hubspot|page_url","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"company_id","field_type":"metric","group":"CLI","slug":"hubspot|company_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"company_property_history_name","field_type":"dimension","group":"CLI","slug":"hubspot|company_property_history_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"company_property_history_value","field_type":"dimension","group":"CLI","slug":"hubspot|company_property_history_value","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"thread_id","field_type":"dimension","group":"CLI","slug":"hubspot|thread_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"engagement_email_status","field_type":"dimension","group":"CLI","slug":"hubspot|engagement_email_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"sent_via","field_type":"dimension","group":"CLI","slug":"hubspot|sent_via","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"logged_from","field_type":"dimension","group":"CLI","slug":"hubspot|logged_from","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"error_message","field_type":"dimension","group":"CLI","slug":"hubspot|error_message","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"facsimile_send_id","field_type":"dimension","group":"CLI","slug":"hubspot|facsimile_send_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"post_send_status","field_type":"dimension","group":"CLI","slug":"hubspot|post_send_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"media_processing_status","field_type":"dimension","group":"CLI","slug":"hubspot|media_processing_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"attached_video_opened","field_type":"dimension","group":"CLI","slug":"hubspot|attached_video_opened","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"attached_video_watched","field_type":"dimension","group":"CLI","slug":"hubspot|attached_video_watched","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"attached_video_id","field_type":"dimension","group":"CLI","slug":"hubspot|attached_video_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"recipient_drop_reasons","field_type":"dimension","group":"CLI","slug":"hubspot|recipient_drop_reasons","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"validation_skipped","field_type":"dimension","group":"CLI","slug":"hubspot|validation_skipped","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"email_send_event_id_created","field_type":"dimension","group":"CLI","slug":"hubspot|email_send_event_id_created","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_send_event_id_id","field_type":"dimension","group":"CLI","slug":"hubspot|email_send_event_id_id","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"owner_id","field_type":"metric","group":"CLI","slug":"hubspot|owner_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"owner_type","field_type":"dimension","group":"CLI","slug":"hubspot|owner_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"first_name","field_type":"dimension","group":"CLI","slug":"hubspot|first_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"last_name","field_type":"dimension","group":"CLI","slug":"hubspot|last_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email","field_type":"dimension","group":"CLI","slug":"hubspot|email","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"unknown_visitor_conversation","field_type":"dimension","group":"CLI","slug":"hubspot|unknown_visitor_conversation","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"campaign_guid","field_type":"dimension","group":"CLI","slug":"hubspot|campaign_guid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"calendar_event_name","field_type":"dimension","group":"CLI","slug":"hubspot|calendar_event_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"description","field_type":"dimension","group":"CLI","slug":"hubspot|description","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"url","field_type":"dimension","group":"CLI","slug":"hubspot|url","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"created_by","field_type":"metric","group":"CLI","slug":"hubspot|created_by","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"create_content","field_type":"dimension","group":"CLI","slug":"hubspot|create_content","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"preview_key","field_type":"dimension","group":"CLI","slug":"hubspot|preview_key","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"template_path","field_type":"dimension","group":"CLI","slug":"hubspot|template_path","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"social_username","field_type":"dimension","group":"CLI","slug":"hubspot|social_username","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"social_display_name","field_type":"dimension","group":"CLI","slug":"hubspot|social_display_name","taxon_type":"dimension"}]}
-
-        '
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '22795'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Nov 2020 15:11:14 GMT
-      Via:
-      - kong/2.0.3
-      X-Amzn-Trace-Id:
-      - None
-      X-Kong-Proxy-Latency:
-      - '0'
-      X-Kong-Upstream-Latency:
-      - '92'
-      x-diesel-request-id:
-      - 1e8c23e6-dad5-40fb-a2f5-f5c1679bc11e
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - pano-cli/1.2.0
-    method: GET
-    uri: https://diesel.panoramicapi.com/api/v1/federated/taxonomy/taxons?company_slug=panoramic-z5y1clyi&offset=200&limit=100
-  response:
-    body:
-      string: '{"data":[{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"avatar_url","field_type":"dimension","group":"CLI","slug":"hubspot|avatar_url","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"is_recurring","field_type":"dimension","group":"CLI","slug":"hubspot|is_recurring","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"topic_ids","field_type":"dimension","group":"CLI","slug":"hubspot|topic_ids","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"content_group_id","field_type":"dimension","group":"CLI","slug":"hubspot|content_group_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"group_id","field_type":"dimension","group":"CLI","slug":"hubspot|group_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"group_order","field_type":"dimension","group":"CLI","slug":"hubspot|group_order","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"user_ids","field_type":"dimension","group":"CLI","slug":"hubspot|user_ids","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"user_id","field_type":"metric","group":"CLI","slug":"hubspot|user_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"engagement_task_status","field_type":"dimension","group":"CLI","slug":"hubspot|engagement_task_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"for_object_type","field_type":"dimension","group":"CLI","slug":"hubspot|for_object_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"task_type","field_type":"dimension","group":"CLI","slug":"hubspot|task_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"is_all_day","field_type":"dimension","group":"CLI","slug":"hubspot|is_all_day","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"priority","field_type":"dimension","group":"CLI","slug":"hubspot|priority","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"completion_date","field_type":"metric","group":"CLI","slug":"hubspot|completion_date","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"stage_id","field_type":"dimension","group":"CLI","slug":"hubspot|stage_id","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"probability","field_type":"metric","group":"CLI","slug":"hubspot|probability","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"closed_won","field_type":"dimension","group":"CLI","slug":"hubspot|closed_won","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_closed_amount_in_home_currency","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_closed_amount_in_home_currency","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_brand_or_agency_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_brand_or_agency_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_amount_in_home_currency","field_type":"metric","group":"CLI","slug":"hubspot|property_amount_in_home_currency","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_connectors_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_connectors_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_days_to_close","field_type":"metric","group":"CLI","slug":"hubspot|property_days_to_close","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_budget_confirmed_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_budget_confirmed_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_competitor_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_competitor_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_analytics_source","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_source","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_discovery_completed_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_discovery_completed_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_closed_amount","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_closed_amount","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_data_warehouse_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_data_warehouse_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_budget_c","field_type":"metric","group":"CLI","slug":"hubspot|property_budget_c","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_contract_amount_c","field_type":"metric","group":"CLI","slug":"hubspot|property_contract_amount_c","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_billing_terms_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_billing_terms_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_contract_renewal_date_c","field_type":"metric","group":"CLI","slug":"hubspot|property_contract_renewal_date_c","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_contact_s_first_name_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_contact_s_first_name_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_contact_s_last_name_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_contact_s_last_name_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_contact_s_title_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_contact_s_title_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_created_by_user_id","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_created_by_user_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_contract_type_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_contract_type_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_deal_stage_probability","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_deal_stage_probability","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_projected_amount","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_projected_amount","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_lastmodifieddate","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_lastmodifieddate","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_hs_is_closed","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_is_closed","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_projected_amount_in_home_currency","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_projected_amount_in_home_currency","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_salesforceopportunityid","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_salesforceopportunityid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_merged_object_ids","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_merged_object_ids","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_verified_sal_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_verified_sal_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_sal_amount_total_c","field_type":"metric","group":"CLI","slug":"hubspot|property_sal_amount_total_c","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_opportunity_type_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_opportunity_type_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_opportunity_won_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_opportunity_won_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"deal_pipeline_id","field_type":"dimension","group":"CLI","slug":"hubspot|deal_pipeline_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hubspot_owner_assigneddate","field_type":"dimension","group":"CLI","slug":"hubspot|property_hubspot_owner_assigneddate","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_salesforcelastsynctime","field_type":"dimension","group":"CLI","slug":"hubspot|property_salesforcelastsynctime","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_dealname","field_type":"dimension","group":"CLI","slug":"hubspot|property_dealname","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_closedate","field_type":"dimension","group":"CLI","slug":"hubspot|property_closedate","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_referrer_paid_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_referrer_paid_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_sal_recorded_month_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_sal_recorded_month_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_createdate","field_type":"dimension","group":"CLI","slug":"hubspot|property_createdate","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_roi_analysis_completed_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_roi_analysis_completed_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"deal_pipeline_stage_id","field_type":"dimension","group":"CLI","slug":"hubspot|deal_pipeline_stage_id","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_sal_amount_oustanding_c","field_type":"metric","group":"CLI","slug":"hubspot|property_sal_amount_oustanding_c","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_amount","field_type":"metric","group":"CLI","slug":"hubspot|property_amount","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_originator_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_originator_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_sal_amount_paid_c","field_type":"metric","group":"CLI","slug":"hubspot|property_sal_amount_paid_c","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_sal_paid_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_sal_paid_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_loss_reason_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_loss_reason_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_sales_forecast_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_sales_forecast_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_updated_by_user_id","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_updated_by_user_id","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_user_ids_of_all_owners","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_user_ids_of_all_owners","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_referrer_name_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_referrer_name_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_notes_last_updated","field_type":"dimension","group":"CLI","slug":"hubspot|property_notes_last_updated","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_referrer_to_be_paid_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_referrer_to_be_paid_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_referral_amount_unpaid_c","field_type":"metric","group":"CLI","slug":"hubspot|property_referral_amount_unpaid_c","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_payment_terms_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_payment_terms_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_ref_c","field_type":"metric","group":"CLI","slug":"hubspot|property_ref_c","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_referral_amount_paid_c","field_type":"metric","group":"CLI","slug":"hubspot|property_referral_amount_paid_c","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_notes_from_bryan","field_type":"dimension","group":"CLI","slug":"hubspot|property_notes_from_bryan","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_notes_next_steps","field_type":"dimension","group":"CLI","slug":"hubspot|property_notes_next_steps","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_notes_last_contacted","field_type":"dimension","group":"CLI","slug":"hubspot|property_notes_last_contacted","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_sales_email_last_replied","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_sales_email_last_replied","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_latest_meeting_activity","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_latest_meeting_activity","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_dealtype","field_type":"dimension","group":"CLI","slug":"hubspot|property_dealtype","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_createdate","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_createdate","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_all_owner_ids","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_all_owner_ids","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_description","field_type":"dimension","group":"CLI","slug":"hubspot|property_description","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hubspot_team_id","field_type":"metric","group":"CLI","slug":"hubspot|property_hubspot_team_id","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_all_team_ids","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_all_team_ids","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_all_accessible_team_ids","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_all_accessible_team_ids","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_num_notes","field_type":"metric","group":"CLI","slug":"hubspot|property_num_notes","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_num_contacted_notes","field_type":"metric","group":"CLI","slug":"hubspot|property_num_contacted_notes","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_notes_next_activity_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_notes_next_activity_date","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_num_associated_contacts","field_type":"metric","group":"CLI","slug":"hubspot|property_num_associated_contacts","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_analytics_first_timestamp","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_first_timestamp","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_num_contacts_with_buying_roles","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_num_contacts_with_buying_roles","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_name","field_type":"dimension","group":"CLI","slug":"hubspot|property_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_linkedinbio","field_type":"dimension","group":"CLI","slug":"hubspot|property_linkedinbio","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_founded_year","field_type":"metric","group":"CLI","slug":"hubspot|property_founded_year","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_timezone","field_type":"dimension","group":"CLI","slug":"hubspot|property_timezone","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_total_money_raised","field_type":"dimension","group":"CLI","slug":"hubspot|property_total_money_raised","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_city","field_type":"dimension","group":"CLI","slug":"hubspot|property_city","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_analytics_num_page_views","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_analytics_num_page_views","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_num_decision_makers","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_num_decision_makers","taxon_type":"metric"}]}
-
-        '
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '24900'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Nov 2020 15:11:15 GMT
-      Via:
-      - kong/2.0.3
-      X-Amzn-Trace-Id:
-      - None
-      X-Kong-Proxy-Latency:
-      - '0'
-      X-Kong-Upstream-Latency:
-      - '74'
-      x-diesel-request-id:
-      - c088f4c6-21cb-459f-9efa-22413bcf5e1c
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - pano-cli/1.2.0
-    method: GET
-    uri: https://diesel.panoramicapi.com/api/v1/federated/taxonomy/taxons?company_slug=panoramic-z5y1clyi&offset=300&limit=100
-  response:
-    body:
-      string: '{"data":[{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_panoramic_client_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_panoramic_client_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_num_open_deals","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_num_open_deals","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_salesforceaccountid","field_type":"dimension","group":"CLI","slug":"hubspot|property_salesforceaccountid","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_num_blockers","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_num_blockers","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_facebook_company_page","field_type":"dimension","group":"CLI","slug":"hubspot|property_facebook_company_page","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_analytics_num_visits","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_analytics_num_visits","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_operam_client_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_operam_client_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_address","field_type":"dimension","group":"CLI","slug":"hubspot|property_address","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_current_client_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_current_client_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_linkedin_company_page","field_type":"dimension","group":"CLI","slug":"hubspot|property_linkedin_company_page","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_total_deal_value","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_total_deal_value","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_target_account_probability","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_target_account_probability","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_is_public","field_type":"dimension","group":"CLI","slug":"hubspot|property_is_public","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_twitterhandle","field_type":"dimension","group":"CLI","slug":"hubspot|property_twitterhandle","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_account_number_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_account_number_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_phone","field_type":"dimension","group":"CLI","slug":"hubspot|property_phone","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_lead_number_c","field_type":"metric","group":"CLI","slug":"hubspot|property_lead_number_c","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_address_2","field_type":"dimension","group":"CLI","slug":"hubspot|property_address_2","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_lfapp_view_in_leadfeeder","field_type":"dimension","group":"CLI","slug":"hubspot|property_lfapp_view_in_leadfeeder","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_num_associated_deals","field_type":"metric","group":"CLI","slug":"hubspot|property_num_associated_deals","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_first_deal_created_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_first_deal_created_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_analytics_last_visit_timestamp","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_last_visit_timestamp","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_analytics_first_visit_timestamp","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_first_visit_timestamp","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_analytics_last_timestamp","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_last_timestamp","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_last_booked_meeting_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_last_booked_meeting_date","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_num_conversion_events","field_type":"metric","group":"CLI","slug":"hubspot|property_num_conversion_events","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_first_conversion_event_name","field_type":"dimension","group":"CLI","slug":"hubspot|property_first_conversion_event_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_recent_conversion_event_name","field_type":"dimension","group":"CLI","slug":"hubspot|property_recent_conversion_event_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_recent_conversion_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_recent_conversion_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_first_conversion_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_first_conversion_date","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_total_revenue","field_type":"metric","group":"CLI","slug":"hubspot|property_total_revenue","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_recent_deal_close_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_recent_deal_close_date","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_recent_deal_amount","field_type":"metric","group":"CLI","slug":"hubspot|property_recent_deal_amount","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_media_spend_c","field_type":"metric","group":"CLI","slug":"hubspot|property_media_spend_c","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_last_open_task_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_last_open_task_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_lfapp_latest_visit","field_type":"dimension","group":"CLI","slug":"hubspot|property_lfapp_latest_visit","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_salesforcedeleted","field_type":"dimension","group":"CLI","slug":"hubspot|property_salesforcedeleted","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_last_sales_activity_timestamp","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_last_sales_activity_timestamp","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_last_sales_activity_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_last_sales_activity_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_last_logged_call_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_last_logged_call_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_domain","field_type":"dimension","group":"CLI","slug":"hubspot|property_domain","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_industry","field_type":"dimension","group":"CLI","slug":"hubspot|property_industry","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_zip","field_type":"dimension","group":"CLI","slug":"hubspot|property_zip","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_website","field_type":"dimension","group":"CLI","slug":"hubspot|property_website","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_state","field_type":"dimension","group":"CLI","slug":"hubspot|property_state","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_web_technologies","field_type":"dimension","group":"CLI","slug":"hubspot|property_web_technologies","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_country","field_type":"dimension","group":"CLI","slug":"hubspot|property_country","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hubspot_owner_id","field_type":"metric","group":"CLI","slug":"hubspot|property_hubspot_owner_id","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_annualrevenue","field_type":"metric","group":"CLI","slug":"hubspot|property_annualrevenue","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_first_contact_createdate","field_type":"dimension","group":"CLI","slug":"hubspot|property_first_contact_createdate","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_numberofemployees","field_type":"metric","group":"CLI","slug":"hubspot|property_numberofemployees","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_type","field_type":"dimension","group":"CLI","slug":"hubspot|property_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_lifecyclestage","field_type":"dimension","group":"CLI","slug":"hubspot|property_lifecyclestage","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_num_child_companies","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_num_child_companies","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_analytics_last_touch_converting_campaign","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_last_touch_converting_campaign","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_analytics_first_touch_converting_campaign","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_first_touch_converting_campaign","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"obsoleted_by_id","field_type":"dimension","group":"CLI","slug":"hubspot|obsoleted_by_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"obsoleted_by_created","field_type":"dimension","group":"CLI","slug":"hubspot|obsoleted_by_created","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"browser","field_type":"dimension","group":"CLI","slug":"hubspot|browser","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"location","field_type":"dimension","group":"CLI","slug":"hubspot|location","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"referer","field_type":"dimension","group":"CLI","slug":"hubspot|referer","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_subscription_name","field_type":"dimension","group":"CLI","slug":"hubspot|email_subscription_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_event_bounce_id","field_type":"dimension","group":"CLI","slug":"hubspot|email_event_bounce_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"response","field_type":"dimension","group":"CLI","slug":"hubspot|response","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_event_bounce_status","field_type":"dimension","group":"CLI","slug":"hubspot|email_event_bounce_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_event_sent_id","field_type":"dimension","group":"CLI","slug":"hubspot|email_event_sent_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"from","field_type":"dimension","group":"CLI","slug":"hubspot|from","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"reply_to","field_type":"dimension","group":"CLI","slug":"hubspot|reply_to","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"cc","field_type":"dimension","group":"CLI","slug":"hubspot|cc","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"bcc","field_type":"dimension","group":"CLI","slug":"hubspot|bcc","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"canonical_vid","field_type":"metric","group":"CLI","slug":"hubspot|canonical_vid","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"merged_vids","field_type":"dimension","group":"CLI","slug":"hubspot|merged_vids","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"profile_url","field_type":"dimension","group":"CLI","slug":"hubspot|profile_url","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_assistant_email_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_assistant_email_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_assistant_s_first_name_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_assistant_s_first_name_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_assistant_s_last_name_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_assistant_s_last_name_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_company_size","field_type":"dimension","group":"CLI","slug":"hubspot|property_company_size","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_customer_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_customer_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_data_source_1","field_type":"dimension","group":"CLI","slug":"hubspot|property_data_source_1","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_data_source_2","field_type":"dimension","group":"CLI","slug":"hubspot|property_data_source_2","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_date_of_birth","field_type":"dimension","group":"CLI","slug":"hubspot|property_date_of_birth","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_degree","field_type":"dimension","group":"CLI","slug":"hubspot|property_degree","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_detail_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_detail_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_email_bounced_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_email_bounced_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_field_of_study","field_type":"dimension","group":"CLI","slug":"hubspot|property_field_of_study","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_form_offer","field_type":"dimension","group":"CLI","slug":"hubspot|property_form_offer","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_full_name","field_type":"dimension","group":"CLI","slug":"hubspot|property_full_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_gender","field_type":"dimension","group":"CLI","slug":"hubspot|property_gender","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_graduation_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_graduation_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_avatar_filemanager_key","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_avatar_filemanager_key","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_buying_role","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_buying_role","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_content_membership_notes","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_content_membership_notes","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_content_membership_registration_domain_sent_to","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_content_membership_registration_domain_sent_to","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_content_membership_status","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_content_membership_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_conversations_visitor_email","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_conversations_visitor_email","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_email_hard_bounce_reason","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_hard_bounce_reason","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_email_hard_bounce_reason_enum","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_hard_bounce_reason_enum","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_email_quarantined_reason","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_quarantined_reason","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_emailconfirmationstatus","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_emailconfirmationstatus","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_facebook_click_id","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_facebook_click_id","taxon_type":"dimension"}]}
-
-        '
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '24226'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Nov 2020 15:11:15 GMT
-      Via:
-      - kong/2.0.3
-      X-Amzn-Trace-Id:
-      - None
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '86'
-      x-diesel-request-id:
-      - cd0fcda4-4bee-4d06-9b3a-64726a3fe026
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - pano-cli/1.2.0
-    method: GET
-    uri: https://diesel.panoramicapi.com/api/v1/federated/taxonomy/taxons?company_slug=panoramic-z5y1clyi&offset=400&limit=100
-  response:
-    body:
-      string: '{"data":[{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_facebookid","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_facebookid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_feedback_last_nps_follow_up","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_feedback_last_nps_follow_up","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_feedback_last_nps_rating","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_feedback_last_nps_rating","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_first_engagement_descr","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_first_engagement_descr","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_first_engagement_object_type","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_first_engagement_object_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_google_click_id","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_google_click_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_googleplusid","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_googleplusid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_ip_timezone","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_ip_timezone","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_lead_status","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_lead_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_legal_basis","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_legal_basis","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_linkedinid","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_linkedinid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_marketable_reason_id","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_marketable_reason_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_marketable_reason_type","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_marketable_reason_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_marketable_status","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_marketable_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_marketable_until_renewal","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_marketable_until_renewal","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_predictivescoringtier","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_predictivescoringtier","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_twitterid","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_twitterid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_ip_city","field_type":"dimension","group":"CLI","slug":"hubspot|property_ip_city","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_ip_country","field_type":"dimension","group":"CLI","slug":"hubspot|property_ip_country","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_ip_country_code","field_type":"dimension","group":"CLI","slug":"hubspot|property_ip_country_code","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_ip_latlon","field_type":"dimension","group":"CLI","slug":"hubspot|property_ip_latlon","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_ip_state","field_type":"dimension","group":"CLI","slug":"hubspot|property_ip_state","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_ip_state_code","field_type":"dimension","group":"CLI","slug":"hubspot|property_ip_state_code","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_ip_zipcode","field_type":"dimension","group":"CLI","slug":"hubspot|property_ip_zipcode","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_job_function","field_type":"dimension","group":"CLI","slug":"hubspot|property_job_function","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_job_level","field_type":"dimension","group":"CLI","slug":"hubspot|property_job_level","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_lead_notes_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_lead_notes_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_leadsource","field_type":"dimension","group":"CLI","slug":"hubspot|property_leadsource","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_leadstatus","field_type":"dimension","group":"CLI","slug":"hubspot|property_leadstatus","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_linkedin_profile_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_linkedin_profile_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_marital_status","field_type":"dimension","group":"CLI","slug":"hubspot|property_marital_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_marketer_or_agency_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_marketer_or_agency_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_military_status","field_type":"dimension","group":"CLI","slug":"hubspot|property_military_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_multiple_company_divisions_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_multiple_company_divisions_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_operam_account_lead_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_operam_account_lead_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_opportunitytype_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_opportunitytype_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_persona_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_persona_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_platform_user_type_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_platform_user_type_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_rating","field_type":"dimension","group":"CLI","slug":"hubspot|property_rating","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_referral_origin_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_referral_origin_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_referrer_company_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_referrer_company_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_relationship_status","field_type":"dimension","group":"CLI","slug":"hubspot|property_relationship_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_salesforcecampaignids","field_type":"dimension","group":"CLI","slug":"hubspot|property_salesforcecampaignids","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_salesforcecontactid","field_type":"dimension","group":"CLI","slug":"hubspot|property_salesforcecontactid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_salesforceleadid","field_type":"dimension","group":"CLI","slug":"hubspot|property_salesforceleadid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_salesforceopportunitystage","field_type":"dimension","group":"CLI","slug":"hubspot|property_salesforceopportunitystage","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_salesforceownerid","field_type":"dimension","group":"CLI","slug":"hubspot|property_salesforceownerid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_school","field_type":"dimension","group":"CLI","slug":"hubspot|property_school","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_seniority","field_type":"dimension","group":"CLI","slug":"hubspot|property_seniority","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_sfcampaignid","field_type":"dimension","group":"CLI","slug":"hubspot|property_sfcampaignid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_source_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_source_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_stage_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_stage_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_start_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_start_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_submitterip_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_submitterip_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_type_of_media_relationship_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_type_of_media_relationship_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_unbouncepageid_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_unbouncepageid_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_unbouncepagevariant_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_unbouncepagevariant_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_unbouncesubmissiondate_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_unbouncesubmissiondate_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_unbouncesubmissiontime_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_unbouncesubmissiontime_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_utm_campaign","field_type":"dimension","group":"CLI","slug":"hubspot|property_utm_campaign","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_utm_medium","field_type":"dimension","group":"CLI","slug":"hubspot|property_utm_medium","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_utm_source","field_type":"dimension","group":"CLI","slug":"hubspot|property_utm_source","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_utm_term","field_type":"dimension","group":"CLI","slug":"hubspot|property_utm_term","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_want_demo","field_type":"dimension","group":"CLI","slug":"hubspot|property_want_demo","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_work_email","field_type":"dimension","group":"CLI","slug":"hubspot|property_work_email","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_firstname","field_type":"dimension","group":"CLI","slug":"hubspot|property_firstname","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_analytics_first_url","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_first_url","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_email_optout_7903713","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_optout_7903713","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_email_optout_9573350","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_optout_9573350","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_currentlyinworkflow","field_type":"dimension","group":"CLI","slug":"hubspot|property_currentlyinworkflow","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_analytics_last_url","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_last_url","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_lastname","field_type":"dimension","group":"CLI","slug":"hubspot|property_lastname","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_salutation","field_type":"dimension","group":"CLI","slug":"hubspot|property_salutation","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_twitterprofilephoto","field_type":"dimension","group":"CLI","slug":"hubspot|property_twitterprofilephoto","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_persona","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_persona","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_mobilephone","field_type":"dimension","group":"CLI","slug":"hubspot|property_mobilephone","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_fax","field_type":"dimension","group":"CLI","slug":"hubspot|property_fax","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_email_last_email_name","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_last_email_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_engagements_last_meeting_booked_campaign","field_type":"dimension","group":"CLI","slug":"hubspot|property_engagements_last_meeting_booked_campaign","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_engagements_last_meeting_booked_medium","field_type":"dimension","group":"CLI","slug":"hubspot|property_engagements_last_meeting_booked_medium","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_engagements_last_meeting_booked_source","field_type":"dimension","group":"CLI","slug":"hubspot|property_engagements_last_meeting_booked_source","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_owneremail","field_type":"dimension","group":"CLI","slug":"hubspot|property_owneremail","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_ownername","field_type":"dimension","group":"CLI","slug":"hubspot|property_ownername","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_twitterbio","field_type":"dimension","group":"CLI","slug":"hubspot|property_twitterbio","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_language","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_language","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_analytics_first_referrer","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_first_referrer","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_jobtitle","field_type":"dimension","group":"CLI","slug":"hubspot|property_jobtitle","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_photo","field_type":"dimension","group":"CLI","slug":"hubspot|property_photo","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_analytics_last_referrer","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_last_referrer","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_message","field_type":"dimension","group":"CLI","slug":"hubspot|property_message","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_company","field_type":"dimension","group":"CLI","slug":"hubspot|property_company","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_numemployees","field_type":"dimension","group":"CLI","slug":"hubspot|property_numemployees","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_predictivecontactscorebucket","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_predictivecontactscorebucket","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_analytics_revenue","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_analytics_revenue","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_hs_email_quarantined","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_quarantined","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_hs_is_unworked","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_is_unworked","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_analytics_average_page_views","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_analytics_average_page_views","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_associatedcompanyid","field_type":"metric","group":"CLI","slug":"hubspot|property_associatedcompanyid","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_analytics_num_event_completions","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_analytics_num_event_completions","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_social_facebook_clicks","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_social_facebook_clicks","taxon_type":"metric"}]}
-
-        '
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '23716'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Nov 2020 15:11:16 GMT
-      Via:
-      - kong/2.0.3
-      X-Amzn-Trace-Id:
-      - None
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '79'
-      x-diesel-request-id:
-      - 26ce4805-3940-4f81-94a7-bba23b76f5f5
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - pano-cli/1.2.0
-    method: GET
-    uri: https://diesel.panoramicapi.com/api/v1/federated/taxonomy/taxons?company_slug=panoramic-z5y1clyi&offset=500&limit=100
-  response:
-    body:
-      string: '{"data":[{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_social_last_engagement","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_social_last_engagement","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_social_google_plus_clicks","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_social_google_plus_clicks","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_social_linkedin_clicks","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_social_linkedin_clicks","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_lastmodifieddate","field_type":"dimension","group":"CLI","slug":"hubspot|property_lastmodifieddate","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_hs_email_optout","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_optout","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_social_num_broadcast_clicks","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_social_num_broadcast_clicks","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_lifecyclestage_lead_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_lifecyclestage_lead_date","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_social_twitter_clicks","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_social_twitter_clicks","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_email_first_send_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_first_send_date","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_email_delivered","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_email_delivered","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_email_first_open_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_first_open_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_email_last_send_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_last_send_date","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_email_sends_since_last_engagement","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_email_sends_since_last_engagement","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_email_open","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_email_open","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_email_last_open_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_last_open_date","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_email_bounce","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_email_bounce","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_email_first_click_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_first_click_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_email_last_click_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_last_click_date","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_email_click","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_email_click","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_lifecyclestage_other_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_lifecyclestage_other_date","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_time_to_first_engagement","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_time_to_first_engagement","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_lifecyclestage_opportunity_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_lifecyclestage_opportunity_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_hs_facebook_ad_clicked","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_facebook_ad_clicked","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_lifecyclestage_subscriber_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_lifecyclestage_subscriber_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_hs_email_bad_address","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_bad_address","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_first_engagement_object_id","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_first_engagement_object_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_hs_created_by_conversations","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_created_by_conversations","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_sales_email_last_opened","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_sales_email_last_opened","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_sa_first_engagement_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_sa_first_engagement_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_facebook_lead_id","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_facebook_lead_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_marketing_pain_point","field_type":"dimension","group":"CLI","slug":"hubspot|property_marketing_pain_point","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_what_benefit_would_help_your_marketing_team_the_most_right_now_","field_type":"dimension","group":"CLI","slug":"hubspot|property_what_benefit_would_help_your_marketing_team_the_most_right_now_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_what_industry_are_you_in_","field_type":"dimension","group":"CLI","slug":"hubspot|property_what_industry_are_you_in_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_what_is_your_biggest_marketing_pain_point_","field_type":"dimension","group":"CLI","slug":"hubspot|property_what_is_your_biggest_marketing_pain_point_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_what_is_your_role_on_the_team_","field_type":"dimension","group":"CLI","slug":"hubspot|property_what_is_your_role_on_the_team_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_role","field_type":"dimension","group":"CLI","slug":"hubspot|property_role","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_department","field_type":"dimension","group":"CLI","slug":"hubspot|property_department","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_how_do_you_currently_store_your_marketing_data_","field_type":"dimension","group":"CLI","slug":"hubspot|property_how_do_you_currently_store_your_marketing_data_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_how_long_does_it_take_to_group_map_and_model_all_of_your_data_","field_type":"dimension","group":"CLI","slug":"hubspot|property_how_long_does_it_take_to_group_map_and_model_all_of_your_data_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_does_your_marketing_or_analytics_team_want_to_do_any_of_the_following_","field_type":"dimension","group":"CLI","slug":"hubspot|property_does_your_marketing_or_analytics_team_want_to_do_any_of_the_following_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_how_do_you_currently_pull_or_extract_your_marketing_data_","field_type":"dimension","group":"CLI","slug":"hubspot|property_how_do_you_currently_pull_or_extract_your_marketing_data_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_how_do_you_store_your_marketing_data_","field_type":"dimension","group":"CLI","slug":"hubspot|property_how_do_you_store_your_marketing_data_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_what_part_do_you_play_on_the_team_","field_type":"dimension","group":"CLI","slug":"hubspot|property_what_part_do_you_play_on_the_team_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_how_long_does_it_take_you_to_group_map_and_model_your_data_","field_type":"dimension","group":"CLI","slug":"hubspot|property_how_long_does_it_take_you_to_group_map_and_model_your_data_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_how_do_you_currently_extract_or_pull_marketing_data_","field_type":"dimension","group":"CLI","slug":"hubspot|property_how_do_you_currently_extract_or_pull_marketing_data_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_would_you_like_to_take_a_quiz_to_see_how_panoramic_can_help_you_","field_type":"dimension","group":"CLI","slug":"hubspot|property_would_you_like_to_take_a_quiz_to_see_how_panoramic_can_help_you_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_what_is_your_industry_","field_type":"dimension","group":"CLI","slug":"hubspot|property_what_is_your_industry_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_would_you_like_to_do_any_of_the_following_","field_type":"dimension","group":"CLI","slug":"hubspot|property_would_you_like_to_do_any_of_the_following_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_ok_well_let_s_at_least_stay_in_touch_","field_type":"dimension","group":"CLI","slug":"hubspot|property_ok_well_let_s_at_least_stay_in_touch_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_forrester_paper","field_type":"dimension","group":"CLI","slug":"hubspot|property_forrester_paper","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_event_dropped_id","field_type":"dimension","group":"CLI","slug":"hubspot|email_event_dropped_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"drop_reason","field_type":"dimension","group":"CLI","slug":"hubspot|drop_reason","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"drop_message","field_type":"dimension","group":"CLI","slug":"hubspot|drop_message","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"facebook_ads|actions__offsite_conversion_fb_pixel_complete_registration_value
-        ","data_type":"numeric","description":"The number of invites scheduled with
-        Sales.","display_format":"decimal_0","display_name":"Calendy Invites","field_type":"metric","group":"Custom","slug":"calendy_invites","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"fivetran_audit_id","field_type":"dimension","group":"CLI","slug":"hubspot|fivetran_audit_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"message","field_type":"dimension","group":"CLI","slug":"hubspot|message","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"update_started","field_type":"dimension","group":"CLI","slug":"hubspot|update_started","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"update_id","field_type":"dimension","group":"CLI","slug":"hubspot|update_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"schema","field_type":"dimension","group":"CLI","slug":"hubspot|schema","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"table","field_type":"dimension","group":"CLI","slug":"hubspot|table","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"start","field_type":"dimension","group":"CLI","slug":"hubspot|start","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"done","field_type":"dimension","group":"CLI","slug":"hubspot|done","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"rows_updated_or_inserted","field_type":"metric","group":"CLI","slug":"hubspot|rows_updated_or_inserted","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"fivetran_audit_status","field_type":"dimension","group":"CLI","slug":"hubspot|fivetran_audit_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"progress","field_type":"dimension","group":"CLI","slug":"hubspot|progress","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_format":null,"display_name":"Last
-        Activity","field_type":"dimension","group":"CLI","slug":"hubspot|metadata_last_processing_state_change_at","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"concat(adwords|headline_1,\"
-        \" ,\"|\",\" \",adwords|headline_2  )","data_type":"text","description":"Combination
-        of Google Ads Headline 1 and Headline 2 field","display_format":"decimal_2","display_name":"Google
-        Ads Headline Concatenation ","field_type":"dimension","group":"Custom","slug":"google_ads_headline_concatenation","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"checkout_initiated
-        ","data_type":"numeric","description":"Showtime lookup click","display_format":"decimal_0","display_name":"Showtime
-        Lookup","field_type":"metric","group":"Custom","slug":"showtime_lookup","taxon_type":"metric"},{"aggregation":{"type":"avg"},"aggregation_type":"avg","calculation":"spend
-        /panoramic_z5y1clyi__leads_custom ","data_type":"money","description":"Cost
-        per Lead (Lead forms submitted on Pano Landing Page)","display_format":"usd_2","display_name":"CPL
-        (Pano LP)","field_type":"metric","group":"Custom","slug":"cpl_pano_lp","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"parse(merge(?facebook_ads|ad_name,?appnexus|creative_name,?linkedin|creative_id),\"_\",4)","data_type":"text","description":"DNU
-        TEST","display_format":"decimal_2","display_name":"Pano Ad Name 2","field_type":"dimension","group":"Custom","slug":"pano_ad_name_2","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"upper(parse(adwords|campaign_name,\"-\",2))","data_type":"text","description":"Parse.
-        Google Search Only. Campaign type (e.g. Branded or Non Branded) parsed from
-        the naming convention.","display_format":"decimal_2","display_name":"Campaign
-        Type (Part 1)","field_type":"dimension","group":"Custom","slug":"campaign_type","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"parse(adwords|campaign_name,\"-\",4)","data_type":"text","description":"Parse.
-        Google Search Only. Targeted non-brand terms parsed from the naming convention.","display_format":"decimal_2","display_name":"Targeting","field_type":"dimension","group":"Custom","slug":"targeting_1","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_would_you_like_to_see_a_demo_","field_type":"dimension","group":"CLI","slug":"hubspot|property_would_you_like_to_see_a_demo_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_where_are_you_spending_the_majority_your_time_","field_type":"dimension","group":"CLI","slug":"hubspot|property_where_are_you_spending_the_majority_your_time_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_magic_wand","field_type":"dimension","group":"CLI","slug":"hubspot|property_magic_wand","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_if_you_had_a_magic_wand_how_would_you_empower_your_marketing_and_analytics_teams_today_","field_type":"dimension","group":"CLI","slug":"hubspot|property_if_you_had_a_magic_wand_how_would_you_empower_your_marketing_and_analytics_teams_today_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_how_long_does_it_take_your_team_to_group_map_and_model_your_data_","field_type":"dimension","group":"CLI","slug":"hubspot|property_how_long_does_it_take_your_team_to_group_map_and_model_your_data_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_how_do_you_currently_collect_and_store_your_marketing_data_","field_type":"dimension","group":"CLI","slug":"hubspot|property_how_do_you_currently_collect_and_store_your_marketing_data_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_how_do_you_currently_collect_and_store_marketing_data_","field_type":"dimension","group":"CLI","slug":"hubspot|property_how_do_you_currently_collect_and_store_marketing_data_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_lifecyclestage_customer_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_lifecyclestage_customer_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_email_customer_quarantined_reason","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_customer_quarantined_reason","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_sales_email_last_clicked","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_sales_email_last_clicked","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_job_role","field_type":"dimension","group":"CLI","slug":"hubspot|property_job_role","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_title","field_type":"dimension","group":"CLI","slug":"hubspot|property_title","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_lifecyclestage_salesqualifiedlead_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_lifecyclestage_salesqualifiedlead_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_lifecyclestage_marketingqualifiedlead_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_lifecyclestage_marketingqualifiedlead_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_panoramic_lifecycle_stage","field_type":"dimension","group":"CLI","slug":"hubspot|property_panoramic_lifecycle_stage","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_what_industry_do_you_work_in","field_type":"dimension","group":"CLI","slug":"hubspot|property_what_industry_do_you_work_in","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_what_is_your_job_title","field_type":"dimension","group":"CLI","slug":"hubspot|property_what_is_your_job_title","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_what_is_your_job_role","field_type":"dimension","group":"CLI","slug":"hubspot|property_what_is_your_job_role","taxon_type":"dimension"},{"aggregation":{"type":"avg"},"aggregation_type":"avg","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_format":"decimal_0","display_name":"Implicit
-        Score","field_type":"metric","group":"CLI","slug":"hubspot|property_implicit_score","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_format":"decimal_2","display_name":"Explicit
-        Score","field_type":"metric","group":"CLI","slug":"hubspot|property_contact_score","taxon_type":"metric"},{"aggregation":{"type":"avg"},"aggregation_type":"avg","calculation":"panoramic_z5y1clyi__leads_custom
-        /panoramic_z5y1clyi__clicks_to_lp ","data_type":"percent","description":"Total
-        Lead Forms Submitted divided by Total Clicks to Landing Page","display_format":"percent_2","display_name":"Lead
-        Rate (Clicks to LP)","field_type":"metric","group":"Custom","slug":"lead_rate_clicks_to_lp","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"merge(?facebook_ads|ad_name,?appnexus|creative_name,?linkedin|creative_id)","data_type":"text","description":"Custom
-        Pano Ad Name Blending across Platforms","display_format":"decimal_2","display_name":"Pano
-        Ad Name","field_type":"dimension","group":"Custom","slug":"pano_ad_name","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"parse(panoramic_z5y1clyi__pano_ad_name
-        , ''_'', 6)","data_type":"text","description":"Parsed: Landing Page from Pano
-        Ad Name","display_format":"decimal_2","display_name":"Ad Landing Page","field_type":"dimension","group":"Custom","slug":"ad_landing_page","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"checkout_initiated
-        + twitter|conversion_purchases_metric + snapchat|conversion_purchases + conversions","data_type":"numeric","description":"Sacha''s
-        Conversions (twitter, snap, FB)","display_format":"decimal_0","display_name":"Sacha''s
-        Conversions","field_type":"metric","group":"Custom","slug":"sacha_s_conversions","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"parse(panoramic_z5y1clyi__pano_ad_name,\"_\",4)","data_type":"text","description":"Parsed:
-        Creative Name from Pano Ad Name","display_format":"decimal_2","display_name":"Creative
-        Name","field_type":"dimension","group":"Custom","slug":"creative_name","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"upper(parse(adwords|campaign_name,\"-\",3))","data_type":"text","description":"Google
-        Search Only. Campaign type (e.g. Branded or Non Branded) parsed from the naming
-        convention.","display_format":"decimal_2","display_name":"Campaign Type (Part
-        2)","field_type":"dimension","group":"Custom","slug":"targeting","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"merge(?facebook_ads|platform_position,?linkedin|campaign_type,?adwords|ad_group_type,?appnexus|creative_type)","data_type":"text","description":"Pano
-        custom blending of Ad Placement and Type","display_format":"decimal_2","display_name":"Placement/Type","field_type":"dimension","group":"Custom","slug":"ad_placement_type","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"panoramic_z5y1clyi_v_d_s_hubspot|property_implicit_score
-        + panoramic_z5y1clyi_v_d_s_hubspot|property_contact_score ","data_type":"numeric","description":null,"display_format":"decimal_2","display_name":"MQL","field_type":"metric","group":"Custom","slug":"mql","taxon_type":"metric"}]}
-
-        '
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '28110'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Nov 2020 15:11:16 GMT
-      Via:
-      - kong/2.0.3
-      X-Amzn-Trace-Id:
-      - None
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '89'
-      x-diesel-request-id:
-      - ec84ff95-447e-4161-8e94-554b897f424e
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - pano-cli/1.2.0
-    method: GET
-    uri: https://diesel.panoramicapi.com/api/v1/federated/taxonomy/taxons?company_slug=panoramic-z5y1clyi&offset=600&limit=100
-  response:
-    body:
-      string: '{"data":[{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"sumiff(objective_normalized
-        == \"Video Views\" ,impressions_viewed , 0)","data_type":"numeric","description":null,"display_format":"decimal_2","display_name":"Max''s
-        Viewable Impressions","field_type":"metric","group":"Custom","slug":"max_s_viewable_impressions","taxon_type":"metric"}]}
-
-        '
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '366'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Nov 2020 15:11:17 GMT
-      Via:
-      - kong/2.0.3
-      X-Amzn-Trace-Id:
-      - None
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '44'
-      x-diesel-request-id:
-      - b631e031-b403-499a-9b94-6659dd79a424
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - pano-cli/1.2.0
-    method: GET
-    uri: https://a1.panocdn.com/updates/pano-cli/versions.json
-  response:
-    body:
-      string: '{"minimum_supported_version": "1.0.0", "latest_version": "1.2.0"}'
-    headers:
-      Accept-Ranges:
-      - bytes
-      Cache-Control:
-      - max-age=60
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '65'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Nov 2020 15:11:59 GMT
-      ETag:
-      - '"b567ca5ec4a1c3c27497963ad975f8f5"'
-      Last-Modified:
-      - Fri, 30 Oct 2020 21:22:49 GMT
-      Server:
-      - AmazonS3
-      Via:
-      - 1.1 ca8d1424de70ce439236d37048e65f54.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - 5RweQUYq8JVZpW581Rbr4hjjT0yysMp70DJQrGb_954ljzsnQsbr2A==
-      X-Amz-Cf-Pop:
-      - IAD89-C2
-      X-Cache:
-      - RefreshHit from cloudfront
-      x-amz-replication-status:
-      - COMPLETED
-      x-amz-version-id:
-      - 7gL4L94FhP5vViOT0_j0Ees.dSesIhqr
-    status:
-      code: 200
-      message: OK
-- request:
-    body: grant_type=client_credentials&scope=platform
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      Content-Type:
-      - application/x-www-form-urlencoded;charset=UTF-8
-      User-Agent:
-      - pano-cli/1.2.0
-    method: POST
-    uri: https://id.panoramichq.com/oauth2/auscsj124wDoFObOJ4x6/v1/token
-  response:
-    body:
-      string: '{"token_type": "Bearer", "expires_in": 3600, "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
-        "scope": "platform"}'
-    headers:
-      Connection:
-      - Keep-Alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Mon, 02 Nov 2020 15:12:00 GMT
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=315360000; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      X-Robots-Tag:
-      - none
-      cache-control:
-      - no-cache, no-store
-      expires:
-      - '0'
-      p3p:
-      - CP="HONK"
-      pragma:
-      - no-cache
-      set-cookie:
-      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
-      - JSESSIONID=8968FBA64DB0DF50634574DF450BB8FB; Path=/; Secure; HttpOnly
-      x-content-type-options:
-      - nosniff
-      x-okta-request-id:
-      - X6AhwNm18BGM0HgDzp71vwAACXM
-      x-rate-limit-limit:
-      - '1200'
-      x-rate-limit-remaining:
-      - '1198'
-      x-rate-limit-reset:
-      - '1604329968'
-      x-xss-protection:
-      - '0'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - pano-cli/1.2.0
-    method: GET
-    uri: https://diesel.panoramicapi.com/api/v1/federated/virtual-data-source?company_slug=panoramic-z5y1clyi&offset=0&limit=100
-  response:
-    body:
-      string: '{"data":[{"display_name":"Test Dataset","global_slug":"panoramic_z5y1clyi_v_d_s_test_dataset","slug":"test_dataset"}]}
-
-        '
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '119'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Nov 2020 15:12:01 GMT
+      - Fri, 20 Nov 2020 11:28:52 GMT
       Via:
       - kong/2.0.3
       X-Amzn-Trace-Id:
@@ -1678,7 +784,7 @@ interactions:
       X-Kong-Upstream-Latency:
       - '45'
       x-diesel-request-id:
-      - c3a20575-5f58-4435-8aba-a7d1b511395c
+      - a7eb1648-87f7-4b10-9354-2af9fae9675b
     status:
       code: 200
       message: OK
@@ -1696,7 +802,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded;charset=UTF-8
       User-Agent:
-      - pano-cli/1.2.0
+      - pano-cli/1.4.0
     method: POST
     uri: https://id.panoramichq.com/oauth2/auscsj124wDoFObOJ4x6/v1/token
   response:
@@ -1709,7 +815,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 02 Nov 2020 15:12:02 GMT
+      - Fri, 20 Nov 2020 11:28:52 GMT
       Keep-Alive:
       - timeout=5, max=100
       Server:
@@ -1730,17 +836,17 @@ interactions:
       - no-cache
       set-cookie:
       - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
-      - JSESSIONID=3AB04A00025A203C1C20451F5B176E21; Path=/; Secure; HttpOnly
+      - JSESSIONID=5572753D13A20A44A69A94513E79A753; Path=/; Secure; HttpOnly
       x-content-type-options:
       - nosniff
       x-okta-request-id:
-      - X6AhwnpxffQERFADEGB0FwAAAbE
+      - X7eodGJxZFlkQaWEcVfHiwAAARA
       x-rate-limit-limit:
       - '1200'
       x-rate-limit-remaining:
-      - '1197'
+      - '1182'
       x-rate-limit-reset:
-      - '1604329968'
+      - '1605871743'
       x-xss-protection:
       - '0'
     status:
@@ -1756,23 +862,284 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - pano-cli/1.2.0
+      - pano-cli/1.4.0
     method: GET
-    uri: https://diesel.panoramicapi.com/api/v1/federated/model/?virtual_data_source=test_dataset&company_slug=panoramic-z5y1clyi&offset=0&limit=100
+    uri: https://diesel.panoramicapi.com/api/v1/federated/model/?virtual_data_source=test_dataset&company_slug=panoramic-cli-e2e-c2m6qp4u&offset=0&limit=100
   response:
     body:
-      string: '{"data":[{"data_source":"pano_snowflake_66.snowflake_sample_data.tpch_sf1.nation","fields":[{"data_reference":"\"N_NAME\"","data_type":null,"field_map":["name"]}],"identifiers":["name"],"joins":[{"fields":["name"],"join_type":"left","relationship":"many_to_one","to_model":"other_model"}],"model_name":"test_model","visibility":"available"}]}
+      string: '{"data":[{"data_source":"pano_snowflake_panoramic_cli_e_2_e_c_2_m_6_qp_4_u.snowflake_sample_data.tpch_sf1.nation","fields":[{"data_reference":"\"N_NAME\"","data_type":null,"field_map":["dataset_test_field"]}],"identifiers":["dataset_test_field"],"joins":[{"fields":["dataset_test_field"],"join_type":"left","relationship":"many_to_one","to_model":"other_model"}],"model_name":"test_model","visibility":"available"}]}
 
         '
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '343'
+      - '417'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Nov 2020 15:12:03 GMT
+      - Fri, 20 Nov 2020 11:28:53 GMT
+      Via:
+      - kong/2.0.3
+      X-Amzn-Trace-Id:
+      - None
+      X-Kong-Proxy-Latency:
+      - '1'
+      X-Kong-Upstream-Latency:
+      - '50'
+      x-diesel-request-id:
+      - c53da660-ce0e-4cb8-ad48-0e31521af45d
+    status:
+      code: 200
+      message: OK
+- request:
+    body: grant_type=client_credentials&scope=platform
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      User-Agent:
+      - pano-cli/1.4.0
+    method: POST
+    uri: https://id.panoramichq.com/oauth2/auscsj124wDoFObOJ4x6/v1/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": 3600, "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+        "scope": "platform"}'
+    headers:
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Fri, 20 Nov 2020 11:28:53 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      cache-control:
+      - no-cache, no-store
+      expires:
+      - '0'
+      p3p:
+      - CP="HONK"
+      pragma:
+      - no-cache
+      set-cookie:
+      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      - JSESSIONID=4D662A0713802A0A60CEB200D12CAE5E; Path=/; Secure; HttpOnly
+      x-content-type-options:
+      - nosniff
+      x-okta-request-id:
+      - X7eodW-2bGbaUq99Q1ELrQAAAco
+      x-rate-limit-limit:
+      - '1200'
+      x-rate-limit-remaining:
+      - '1181'
+      x-rate-limit-reset:
+      - '1605871743'
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - pano-cli/1.4.0
+    method: GET
+    uri: https://diesel.panoramicapi.com/api/v1/federated/taxonomy/taxons?company_slug=panoramic-cli-e2e-c2m6qp4u&offset=0&limit=100
+  response:
+    body:
+      string: '{"data":[{"acronym":null,"aggregation":{"type":"group_by"},"aggregation_type":"group_by","calculation":"2
+        + 2","data_type":"text","description":null,"display_format":null,"display_name":"Company
+        test field","field_type":"dimension","group":"Custom","slug":"company_test_field","taxon_type":"dimension","validation_type":"text"},{"acronym":null,"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"test_dataset","data_type":"text","description":null,"display_format":null,"display_name":"Dataset
+        test field","field_type":"metric","group":"Custom","slug":"test_dataset|dataset_test_field","taxon_type":"metric","validation_type":"text"}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '672'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Nov 2020 11:28:54 GMT
+      Via:
+      - kong/2.0.3
+      X-Amzn-Trace-Id:
+      - None
+      X-Kong-Proxy-Latency:
+      - '0'
+      X-Kong-Upstream-Latency:
+      - '38'
+      x-diesel-request-id:
+      - 6a6415a7-f12a-4922-91b7-0f6427cc32ce
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - pano-cli/1.4.0
+    method: GET
+    uri: https://a1.panocdn.com/updates/pano-cli/versions.json
+  response:
+    body:
+      string: '{"minimum_supported_version": "1.3.1", "latest_version": "1.3.3"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Age:
+      - '6264'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '65'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Nov 2020 09:44:31 GMT
+      ETag:
+      - '"27c3611f3cf23f5e138de084cc76d1b7"'
+      Last-Modified:
+      - Wed, 18 Nov 2020 13:00:30 GMT
+      Server:
+      - AmazonS3
+      Via:
+      - 1.1 d19e64e406af1f88f7f96d9dcb2393ca.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - Cdvl5XPudAcMZfvi9jGYqTjHT6OyQbcvw5fpIKdZ_gb6auHqApk2lw==
+      X-Amz-Cf-Pop:
+      - IAD89-C2
+      X-Cache:
+      - Hit from cloudfront
+      x-amz-replication-status:
+      - COMPLETED
+      x-amz-version-id:
+      - mG5i_duZYt9G0wN9uH2LFIW2WoQ756Fc
+    status:
+      code: 200
+      message: OK
+- request:
+    body: grant_type=client_credentials&scope=platform
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      User-Agent:
+      - pano-cli/1.4.0
+    method: POST
+    uri: https://id.panoramichq.com/oauth2/auscsj124wDoFObOJ4x6/v1/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": 3600, "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+        "scope": "platform"}'
+    headers:
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Fri, 20 Nov 2020 11:28:55 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      cache-control:
+      - no-cache, no-store
+      expires:
+      - '0'
+      p3p:
+      - CP="HONK"
+      pragma:
+      - no-cache
+      set-cookie:
+      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      - JSESSIONID=BD3BEB8EE41C50EBA2BB0AEA2621E515; Path=/; Secure; HttpOnly
+      x-content-type-options:
+      - nosniff
+      x-okta-request-id:
+      - X7eod@4wbSE1jaYEH7NqkgAAAoE
+      x-rate-limit-limit:
+      - '1200'
+      x-rate-limit-remaining:
+      - '1180'
+      x-rate-limit-reset:
+      - '1605871743'
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - pano-cli/1.4.0
+    method: GET
+    uri: https://diesel.panoramicapi.com/api/v1/federated/virtual-data-source?company_slug=panoramic-cli-e2e-c2m6qp4u&offset=0&limit=100
+  response:
+    body:
+      string: '{"data":[{"display_name":"Test Dataset","global_slug":"panoramic_cli_e2e_c2m6qp4u_v_d_s_test_dataset","slug":"test_dataset"}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '127'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Nov 2020 11:28:56 GMT
       Via:
       - kong/2.0.3
       X-Amzn-Trace-Id:
@@ -1782,7 +1149,7 @@ interactions:
       X-Kong-Upstream-Latency:
       - '47'
       x-diesel-request-id:
-      - 26568f21-fdc1-4192-9a2b-c3ec0233a0af
+      - bc28695a-9592-49b4-a4d3-379091139bc4
     status:
       code: 200
       message: OK
@@ -1800,7 +1167,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded;charset=UTF-8
       User-Agent:
-      - pano-cli/1.2.0
+      - pano-cli/1.4.0
     method: POST
     uri: https://id.panoramichq.com/oauth2/auscsj124wDoFObOJ4x6/v1/token
   response:
@@ -1813,7 +1180,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 02 Nov 2020 15:12:05 GMT
+      - Fri, 20 Nov 2020 11:28:56 GMT
       Keep-Alive:
       - timeout=5, max=100
       Server:
@@ -1834,17 +1201,17 @@ interactions:
       - no-cache
       set-cookie:
       - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
-      - JSESSIONID=9372F68E148E7BBC1D25AE31C924E648; Path=/; Secure; HttpOnly
+      - JSESSIONID=44DF55B3576E019ED0E755299167EB28; Path=/; Secure; HttpOnly
       x-content-type-options:
       - nosniff
       x-okta-request-id:
-      - X6AhxDAdikNm13@M8iDgVgAAAAU
+      - X7eoeO4wbSE1jaYEH7NqlgAAAmI
       x-rate-limit-limit:
       - '1200'
       x-rate-limit-remaining:
-      - '1196'
+      - '1179'
       x-rate-limit-reset:
-      - '1604329968'
+      - '1605871743'
       x-xss-protection:
       - '0'
     status:
@@ -1860,80 +1227,23 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - pano-cli/1.2.0
+      - pano-cli/1.4.0
     method: GET
-    uri: https://diesel.panoramicapi.com/api/v1/federated/taxonomy/taxons?company_slug=panoramic-z5y1clyi&offset=0&limit=100
+    uri: https://diesel.panoramicapi.com/api/v1/federated/model/?virtual_data_source=test_dataset&company_slug=panoramic-cli-e2e-c2m6qp4u&offset=0&limit=100
   response:
     body:
-      string: '{"data":[{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_type":"numeric","description":"How
-        much of the expected value has been delivered to the customer","display_name":"Delivery","field_type":"metric","group":"Custom","slug":"delivery","taxon_type":"metric"},{"calculation":null,"data_type":"text","description":null,"display_name":"Health
-        Score Date","field_type":"dimension","group":"Custom","slug":"health_score_date","taxon_type":"dimension"},{"calculation":null,"data_type":"text","description":"Name
-        of Client","display_name":"Account Name","field_type":"dimension","group":"Custom","slug":"account_name","taxon_type":"dimension"},{"calculation":null,"data_type":"text","description":null,"display_name":"Grade","field_type":"dimension","group":"Custom","slug":"grade_1","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_type":"numeric","description":"How
-        the customer feels about the platform","display_name":"Sentiment","field_type":"metric","group":"Custom","slug":"sentiment","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_type":"text","description":null,"display_format":"decimal_2","display_name":"Platform
-        - Pano Test","field_type":"dimension","group":"Custom","slug":"platform_pano_test","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_type":"numeric","description":"Ho
-        much the client is engaged with the platform","display_name":"Usage","field_type":"metric","group":"Custom","slug":"usage","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"contact_list_id","field_type":"metric","group":"CLI","slug":"hubspot|contact_list_id","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"contact_id","field_type":"metric","group":"CLI","slug":"hubspot|contact_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"added_at","field_type":"dimension","group":"CLI","slug":"hubspot|added_at","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_event_delivered_id","field_type":"dimension","group":"CLI","slug":"hubspot|email_event_delivered_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"smtp_id","field_type":"dimension","group":"CLI","slug":"hubspot|smtp_id","taxon_type":"dimension"},{"aggregation":{"type":"avg"},"aggregation_type":"avg","calculation":null,"data_type":"money","description":"Max
-        is testing","display_name":"Max''s CPA","field_type":"metric","group":"Custom","slug":"my_cpa","taxon_type":"metric"},{"calculation":null,"data_type":"text","description":"A
-        conversion is a click on the \"download\" button (traffic to a landing page),
-        so not a true conversion","display_name":"Conversion - LinkedIn","field_type":"dimension","group":"Custom","slug":"conversion_linked_in","taxon_type":"dimension"},{"calculation":null,"data_type":"text","description":"An
-        aggregated and anonymized dataset used for comparison respective to whichever
-        Dimensions (e.g. Objective, Publisher, Age, Country, etc.) have been applied
-        in the platform.","display_name":"Benchmark","field_type":"dimension","group":"Custom","slug":"benchmark","taxon_type":"dimension"},{"calculation":null,"data_type":"text","description":null,"display_format":null,"display_name":"Company
-        test field","field_type":"dimension","group":"Custom","slug":"company_test_field","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"is_deleted","field_type":"dimension","group":"CLI","slug":"hubspot|is_deleted","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_businessunity_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_businessunity_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_analytics_engineer_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_analytics_engineer_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_analytics_source_data_2","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_source_data_2","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_analytics_source_data_1","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_source_data_1","taxon_type":"dimension"},{"calculation":null,"data_source":"test_dataset","data_type":"text","description":null,"display_format":null,"display_name":"Dataset
-        test field","field_type":"metric","group":"Custom","slug":"test_dataset|dataset_test_field","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"
-        (panoramic_z5y1clyi__usage*3)+(2*panoramic_z5y1clyi__delivery)+(panoramic_z5y1clyi__sentiment*5)","data_type":"numeric","description":"Weighted
-        Score","display_name":"Total Score","field_type":"metric","group":"Custom","slug":"total_score","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"merge(?facebook_ads|campaign_name,?linkedin|campaign_group_name)","data_type":"text","description":"Campaign
-        Naming Convention (Social)","display_format":"decimal_2","display_name":"Pano
-        Campaign Name","field_type":"dimension","group":"Custom","slug":"pano_campaign_name","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"?
-        facebook_ads|actions__offsite_conversion_fb_pixel_lead_value + ?facebook_ads|actions__onsite_conversion__lead_grouped_value  +
-        ?adwords|conversions_purchase + ?linkedin|external_website_conversions + ?appnexus|total_convs
-        ","data_type":"numeric","description":null,"display_format":"decimal_0","display_name":"GH
-        Test","field_type":"metric","group":"Custom","slug":"gh_test","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"merge(?facebook_ads|adset_name,?linkedin|campaign_name)","data_type":"text","description":"Pano
-        Ad Set Name used for Parsing Naming Covention","display_format":"decimal_2","display_name":"Pano
-        Adgroup Name","field_type":"dimension","group":"Custom","slug":"pano_ad_set_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"engagement_type","field_type":"dimension","group":"CLI","slug":"hubspot|engagement_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"activity_type","field_type":"dimension","group":"CLI","slug":"hubspot|activity_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"engagement_last_updated","field_type":"dimension","group":"CLI","slug":"hubspot|engagement_last_updated","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"guid","field_type":"dimension","group":"CLI","slug":"hubspot|guid","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"portal_id","field_type":"metric","group":"CLI","slug":"hubspot|portal_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"form_name","field_type":"dimension","group":"CLI","slug":"hubspot|form_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"action","field_type":"dimension","group":"CLI","slug":"hubspot|action","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"method","field_type":"dimension","group":"CLI","slug":"hubspot|method","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"css_class","field_type":"dimension","group":"CLI","slug":"hubspot|css_class","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"to_number","field_type":"dimension","group":"CLI","slug":"hubspot|to_number","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"from_number","field_type":"dimension","group":"CLI","slug":"hubspot|from_number","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"engagement_call_status","field_type":"dimension","group":"CLI","slug":"hubspot|engagement_call_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"external_id","field_type":"dimension","group":"CLI","slug":"hubspot|external_id","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"duration_milliseconds","field_type":"metric","group":"CLI","slug":"hubspot|duration_milliseconds","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"external_account_id","field_type":"dimension","group":"CLI","slug":"hubspot|external_account_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"recording_url","field_type":"dimension","group":"CLI","slug":"hubspot|recording_url","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"disposition","field_type":"dimension","group":"CLI","slug":"hubspot|disposition","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"callee_object_type","field_type":"dimension","group":"CLI","slug":"hubspot|callee_object_type","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"callee_object_id","field_type":"metric","group":"CLI","slug":"hubspot|callee_object_id","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"transcription_id","field_type":"metric","group":"CLI","slug":"hubspot|transcription_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_email","field_type":"dimension","group":"CLI","slug":"hubspot|property_email","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"change","field_type":"dimension","group":"CLI","slug":"hubspot|change","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"change_type","field_type":"dimension","group":"CLI","slug":"hubspot|change_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"caused_by_event_id","field_type":"dimension","group":"CLI","slug":"hubspot|caused_by_event_id","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"email_subscription_id","field_type":"metric","group":"CLI","slug":"hubspot|email_subscription_id","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"parse(panoramic_z5y1clyi__pano_campaign_name
-        , ''_'', 4)","data_type":"text","description":"Parsed: Campaign Audience Type
-        from Pano Campaign Name","display_format":"decimal_2","display_name":"Campaign
-        Audience Type","field_type":"dimension","group":"Custom","slug":"campaign_audience_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"app_name","field_type":"dimension","group":"CLI","slug":"hubspot|app_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_campaign_name","field_type":"dimension","group":"CLI","slug":"hubspot|email_campaign_name","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"num_included","field_type":"metric","group":"CLI","slug":"hubspot|num_included","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"num_queued","field_type":"metric","group":"CLI","slug":"hubspot|num_queued","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"sub_type","field_type":"dimension","group":"CLI","slug":"hubspot|sub_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_campaign_type","field_type":"dimension","group":"CLI","slug":"hubspot|email_campaign_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"calendar_event_id","field_type":"dimension","group":"CLI","slug":"hubspot|calendar_event_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"event_type","field_type":"dimension","group":"CLI","slug":"hubspot|event_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"event_date","field_type":"dimension","group":"CLI","slug":"hubspot|event_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"category","field_type":"dimension","group":"CLI","slug":"hubspot|category","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"category_id","field_type":"metric","group":"CLI","slug":"hubspot|category_id","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"content_id","field_type":"metric","group":"CLI","slug":"hubspot|content_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"state","field_type":"dimension","group":"CLI","slug":"hubspot|state","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_event_click_id","field_type":"dimension","group":"CLI","slug":"hubspot|email_event_click_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"ip_address","field_type":"dimension","group":"CLI","slug":"hubspot|ip_address","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"user_agent","field_type":"dimension","group":"CLI","slug":"hubspot|user_agent","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_type":"text","description":"this
-        is sacha''s test","display_format":"decimal_2","display_name":"Sacha''s Dimension
-        Test","field_type":"dimension","group":"Custom","slug":"sacha_s_dimension_test","taxon_type":"dimension"},{"calculation":null,"data_type":"text","description":"Testing","display_format":null,"display_name":"Panoramic
-        test","field_type":"dimension","group":"Custom","slug":"panoramic_test","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"concat(panoramic_z5y1clyi__campaign_type,\"
-        \",panoramic_z5y1clyi__targeting)","data_type":"text","description":"Concat.
-        Google Search. Branded or Non-Branded Campaigns.","display_format":"decimal_2","display_name":"Campaign
-        Type","field_type":"dimension","group":"Custom","slug":"campaign_type_3","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"parse(panoramic_z5y1clyi__pano_ad_name
-        , ''_'',3)","data_type":"text","description":"Parsed: Creative Type from Pano
-        Ad Name","display_format":"decimal_2","display_name":"Creative Type","field_type":"dimension","group":"Custom","slug":"creative_type","taxon_type":"dimension"},{"aggregation":{"type":"avg"},"aggregation_type":"avg","calculation":"panoramic_z5y1clyi_v_d_s_hubspot|property_implicit_score
-        ","data_type":"numeric","description":"Average of Implicit Score","display_format":"decimal_0","display_name":"Implicit
-        Score (Avg)","field_type":"metric","group":"Custom","slug":"implicit_score_avg","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"merge(?facebook_ads|ad_name,?panoramic_z5y1clyi__google_ads_headline_concatenation,?appnexus|creative_name,?linkedin|creative_id)","data_type":"text","description":"DNU
-        Testing Ad Name Merge","display_format":"decimal_2","display_name":"DNU Ad
-        Name Merge","field_type":"dimension","group":"Custom","slug":"dnu_ad_name_merge","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"?adwords|conversions_purchase
-        + ?linkedin|external_website_conversions + ?appnexus|total_convs + ?facebook_ads|actions__offsite_conversion_fb_pixel_lead_value
-        + ?facebook_ads|actions__onsite_conversion__lead_grouped_value ","data_type":"numeric","description":"Total
-        Lead Forms Submitted on Pano Landing Page","display_format":"decimal_0","display_name":"Leads
-        (Pano LP)","field_type":"metric","group":"Custom","slug":"leads_custom","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"coalesce(panoramic_z5y1clyi__showtime_lookup_1
-        ,impressions )","data_type":"numeric","description":null,"display_format":"decimal_2","display_name":"KT
-        test DNU","field_type":"metric","group":"Custom","slug":"kt_test_dnu","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"vid","field_type":"dimension","group":"CLI","slug":"hubspot|vid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"saved_at_timestamp","field_type":"dimension","group":"CLI","slug":"hubspot|saved_at_timestamp","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"deleted_changed_timestamp","field_type":"dimension","group":"CLI","slug":"hubspot|deleted_changed_timestamp","taxon_type":"dimension"},{"aggregation":{"type":"avg"},"aggregation_type":"avg","calculation":"300*1","data_type":"money","description":"8/1/20
-        - 8/31/20 CPL (Pano LP) Goal","display_format":"usd_2","display_name":"GOAL:
-        CPL (Pano LP)","field_type":"metric","group":"Custom","slug":"cpl_goal","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"from_email","field_type":"dimension","group":"CLI","slug":"hubspot|from_email","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"from_first_name","field_type":"dimension","group":"CLI","slug":"hubspot|from_first_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"from_last_name","field_type":"dimension","group":"CLI","slug":"hubspot|from_last_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"subject","field_type":"dimension","group":"CLI","slug":"hubspot|subject","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"html","field_type":"dimension","group":"CLI","slug":"hubspot|html","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"text","field_type":"dimension","group":"CLI","slug":"hubspot|text","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"tracker_key","field_type":"dimension","group":"CLI","slug":"hubspot|tracker_key","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"message_id","field_type":"dimension","group":"CLI","slug":"hubspot|message_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"contact_list_name","field_type":"dimension","group":"CLI","slug":"hubspot|contact_list_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"deleteable","field_type":"dimension","group":"CLI","slug":"hubspot|deleteable","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"dynamic","field_type":"dimension","group":"CLI","slug":"hubspot|dynamic","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"metadata_processing","field_type":"dimension","group":"CLI","slug":"hubspot|metadata_processing","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"metadata_last_size_change_at","field_type":"dimension","group":"CLI","slug":"hubspot|metadata_last_size_change_at","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"metadata_error","field_type":"dimension","group":"CLI","slug":"hubspot|metadata_error","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"offset","field_type":"metric","group":"CLI","slug":"hubspot|offset","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_format":"decimal_0","display_name":"Size","field_type":"metric","group":"CLI","slug":"hubspot|metadata_size","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"parse(panoramic_z5y1clyi__pano_ad_set_name
-        , ''_'', 4)","data_type":"text","description":"Parsed: Ad Set Audience from
-        Pano Ad Set Name","display_format":"decimal_2","display_name":"Adgroup Audience","field_type":"dimension","group":"Custom","slug":"ad_set_audience","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"searches
-        ","data_type":"numeric","description":"Showtime Lookup","display_format":"decimal_2","display_name":"Showtime
-        Lookup","field_type":"metric","group":"Custom","slug":"showtime_lookup_1","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"?linkedin|landing_page_clicks
-        + ?adwords|clicks + ?facebook_ads|actions__link_click_value + ?appnexus|clicks
-        ","data_type":"numeric","description":"Total Clicks to Landing Page","display_format":"decimal_0","display_name":"Clicks
-        to LP","field_type":"metric","group":"Custom","slug":"clicks_to_lp","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"parse(panoramic_z5y1clyi__pano_campaign_name
-        , ''_'',  3)","data_type":"text","description":"Parsed: Campaign Audience
-        Group from Pano Naming Convention","display_format":"decimal_2","display_name":"Campaign
-        Audience Group","field_type":"dimension","group":"Custom","slug":"campaign_audience_group","taxon_type":"dimension"}]}
+      string: '{"data":[{"data_source":"pano_snowflake_panoramic_cli_e_2_e_c_2_m_6_qp_4_u.snowflake_sample_data.tpch_sf1.nation","fields":[{"data_reference":"\"N_NAME\"","data_type":null,"field_map":["dataset_test_field"]}],"identifiers":["dataset_test_field"],"joins":[{"fields":["dataset_test_field"],"join_type":"left","relationship":"many_to_one","to_model":"other_model"}],"model_name":"test_model","visibility":"available"}]}
 
         '
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '24902'
+      - '417'
       Content-Type:
       - application/json
       Date:
-      - Mon, 02 Nov 2020 15:12:05 GMT
+      - Fri, 20 Nov 2020 11:28:57 GMT
       Via:
       - kong/2.0.3
       X-Amzn-Trace-Id:
@@ -1941,298 +1251,9 @@ interactions:
       X-Kong-Proxy-Latency:
       - '0'
       X-Kong-Upstream-Latency:
-      - '82'
+      - '33'
       x-diesel-request-id:
-      - 97de66d5-a9c4-47d2-972e-ea640ea6bcd5
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - pano-cli/1.2.0
-    method: GET
-    uri: https://diesel.panoramicapi.com/api/v1/federated/taxonomy/taxons?company_slug=panoramic-z5y1clyi&offset=100&limit=100
-  response:
-    body:
-      string: '{"data":[{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"parse(panoramic_z5y1clyi__pano_ad_name
-        , ''_'', 5)","data_type":"text","description":"Parsed: Ad Text/Copy from Pano
-        Ad Name","display_format":"decimal_2","display_name":"Ad Text/Copy","field_type":"dimension","group":"Custom","slug":"ad_text_copy","taxon_type":"dimension"},{"aggregation":{"type":"avg"},"aggregation_type":"avg","calculation":"spend
-        / panoramic_z5y1clyi__clicks_to_lp ","data_type":"money","description":"Cost
-        per Landing Page Click","display_format":"usd_2","display_name":"CPC (LP)","field_type":"metric","group":"Custom","slug":"cpc_lp","taxon_type":"metric"},{"calculation":null,"data_type":"text","description":null,"display_format":null,"display_name":"Objective","field_type":"dimension","group":"Custom","slug":"objective","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"sumiff(data_source==\"facebook_ads\",30,sumiff(data_source==\"linkedin\",25,sumiff(data_source==\"adwords\",75)))","data_type":"numeric","description":"Data
-        Source Leads (Pano LP) Goal for 8/1-8/31","display_format":"decimal_0","display_name":"GOAL:
-        Leads (Pano LP)","field_type":"metric","group":"Custom","slug":"test_leads_goal","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"merge(facebook_ads|effective_status,adwords|campaign_state,linkedin|status,appnexus|campaign_state
-        )","data_type":"text","description":"Custom Field. The status of your campaign
-        - example statuses are pending, active, inactive, and ended.","display_format":"decimal_2","display_name":"Campaign
-        Status","field_type":"dimension","group":"Custom","slug":"campaign_status_pano","taxon_type":"dimension"},{"aggregation":{"type":"avg"},"aggregation_type":"avg","calculation":"5","data_type":"money","description":null,"display_format":"usd_2","display_name":"Max''s
-        Benchmark","field_type":"metric","group":"Custom","slug":"max_s_benchmark","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"contact_property_history_value","field_type":"dimension","group":"CLI","slug":"hubspot|contact_property_history_value","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_format":null,"display_name":"contact_property_history_name","field_type":"dimension","group":"CLI","slug":"hubspot|contact_property_history_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_event_id","field_type":"dimension","group":"CLI","slug":"hubspot|email_event_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"created","field_type":"dimension","group":"CLI","slug":"hubspot|created","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_event_type","field_type":"dimension","group":"CLI","slug":"hubspot|email_event_type","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"app_id","field_type":"metric","group":"CLI","slug":"hubspot|app_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"filtered_event","field_type":"dimension","group":"CLI","slug":"hubspot|filtered_event","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"email_campaign_id","field_type":"metric","group":"CLI","slug":"hubspot|email_campaign_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"sent_by_id","field_type":"dimension","group":"CLI","slug":"hubspot|sent_by_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"sent_by_created","field_type":"dimension","group":"CLI","slug":"hubspot|sent_by_created","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"caused_by_id","field_type":"dimension","group":"CLI","slug":"hubspot|caused_by_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"caused_by_created","field_type":"dimension","group":"CLI","slug":"hubspot|caused_by_created","taxon_type":"dimension"},{"aggregation":{"type":"avg"},"aggregation_type":"avg","calculation":"panoramic_z5y1clyi__clicks_to_lp
-        / impressions","data_type":"percent","description":"Click Through Rate to
-        Landing Page","display_format":"percent_2","display_name":"CTR (LP)","field_type":"metric","group":"Custom","slug":"lp_click_rate","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"engagement_id","field_type":"metric","group":"CLI","slug":"hubspot|engagement_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"body","field_type":"dimension","group":"CLI","slug":"hubspot|body","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"start_time","field_type":"dimension","group":"CLI","slug":"hubspot|start_time","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"end_time","field_type":"dimension","group":"CLI","slug":"hubspot|end_time","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"engagement_meeting_title","field_type":"dimension","group":"CLI","slug":"hubspot|engagement_meeting_title","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"external_url","field_type":"dimension","group":"CLI","slug":"hubspot|external_url","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"created_from_link_id","field_type":"metric","group":"CLI","slug":"hubspot|created_from_link_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"web_conference_meeting_id","field_type":"dimension","group":"CLI","slug":"hubspot|web_conference_meeting_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"pre_meeting_prospect_reminders","field_type":"dimension","group":"CLI","slug":"hubspot|pre_meeting_prospect_reminders","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_event_status_change_id","field_type":"dimension","group":"CLI","slug":"hubspot|email_event_status_change_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"requested_by","field_type":"dimension","group":"CLI","slug":"hubspot|requested_by","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"portal_subscription_status","field_type":"dimension","group":"CLI","slug":"hubspot|portal_subscription_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"subscriptions","field_type":"dimension","group":"CLI","slug":"hubspot|subscriptions","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"bounced","field_type":"dimension","group":"CLI","slug":"hubspot|bounced","taxon_type":"dimension"},{"calculation":null,"data_source":"test_dataset","data_type":"text","description":null,"display_name":"name","field_type":"dimension","group":"CLI","slug":"test_dataset|name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_event_open_id","field_type":"dimension","group":"CLI","slug":"hubspot|email_event_open_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"duration","field_type":"dimension","group":"CLI","slug":"hubspot|duration","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"redirect","field_type":"dimension","group":"CLI","slug":"hubspot|redirect","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"submit_text","field_type":"dimension","group":"CLI","slug":"hubspot|submit_text","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"follow_up_id","field_type":"dimension","group":"CLI","slug":"hubspot|follow_up_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"notify_recipients","field_type":"dimension","group":"CLI","slug":"hubspot|notify_recipients","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"lead_nurturing_campaign_id","field_type":"dimension","group":"CLI","slug":"hubspot|lead_nurturing_campaign_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"created_at","field_type":"dimension","group":"CLI","slug":"hubspot|created_at","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"updated_at","field_type":"dimension","group":"CLI","slug":"hubspot|updated_at","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"_fivetran_deleted","field_type":"dimension","group":"CLI","slug":"hubspot|_fivetran_deleted","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"_fivetran_synced","field_type":"dimension","group":"CLI","slug":"hubspot|_fivetran_synced","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_event_deferred_id","field_type":"dimension","group":"CLI","slug":"hubspot|email_event_deferred_id","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"attempt","field_type":"metric","group":"CLI","slug":"hubspot|attempt","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"pipeline_id","field_type":"dimension","group":"CLI","slug":"hubspot|pipeline_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"label","field_type":"dimension","group":"CLI","slug":"hubspot|label","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"active","field_type":"dimension","group":"CLI","slug":"hubspot|active","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"display_order","field_type":"metric","group":"CLI","slug":"hubspot|display_order","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"deal_id","field_type":"metric","group":"CLI","slug":"hubspot|deal_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"deal_property_history_name","field_type":"dimension","group":"CLI","slug":"hubspot|deal_property_history_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"timestamp","field_type":"dimension","group":"CLI","slug":"hubspot|timestamp","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"deal_property_history_value","field_type":"dimension","group":"CLI","slug":"hubspot|deal_property_history_value","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"source_id","field_type":"dimension","group":"CLI","slug":"hubspot|source_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"source","field_type":"dimension","group":"CLI","slug":"hubspot|source","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"identity_vid","field_type":"dimension","group":"CLI","slug":"hubspot|identity_vid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"identity_profile_identity_value","field_type":"dimension","group":"CLI","slug":"hubspot|identity_profile_identity_value","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"identity_profile_identity_type","field_type":"dimension","group":"CLI","slug":"hubspot|identity_profile_identity_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"is_primary","field_type":"dimension","group":"CLI","slug":"hubspot|is_primary","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"is_secondary","field_type":"dimension","group":"CLI","slug":"hubspot|is_secondary","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"conversion_id","field_type":"dimension","group":"CLI","slug":"hubspot|conversion_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"contact_form_submission_title","field_type":"dimension","group":"CLI","slug":"hubspot|contact_form_submission_title","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"form_id","field_type":"dimension","group":"CLI","slug":"hubspot|form_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"page_url","field_type":"dimension","group":"CLI","slug":"hubspot|page_url","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"company_id","field_type":"metric","group":"CLI","slug":"hubspot|company_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"company_property_history_name","field_type":"dimension","group":"CLI","slug":"hubspot|company_property_history_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"company_property_history_value","field_type":"dimension","group":"CLI","slug":"hubspot|company_property_history_value","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"thread_id","field_type":"dimension","group":"CLI","slug":"hubspot|thread_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"engagement_email_status","field_type":"dimension","group":"CLI","slug":"hubspot|engagement_email_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"sent_via","field_type":"dimension","group":"CLI","slug":"hubspot|sent_via","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"logged_from","field_type":"dimension","group":"CLI","slug":"hubspot|logged_from","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"error_message","field_type":"dimension","group":"CLI","slug":"hubspot|error_message","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"facsimile_send_id","field_type":"dimension","group":"CLI","slug":"hubspot|facsimile_send_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"post_send_status","field_type":"dimension","group":"CLI","slug":"hubspot|post_send_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"media_processing_status","field_type":"dimension","group":"CLI","slug":"hubspot|media_processing_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"attached_video_opened","field_type":"dimension","group":"CLI","slug":"hubspot|attached_video_opened","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"attached_video_watched","field_type":"dimension","group":"CLI","slug":"hubspot|attached_video_watched","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"attached_video_id","field_type":"dimension","group":"CLI","slug":"hubspot|attached_video_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"recipient_drop_reasons","field_type":"dimension","group":"CLI","slug":"hubspot|recipient_drop_reasons","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"validation_skipped","field_type":"dimension","group":"CLI","slug":"hubspot|validation_skipped","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"email_send_event_id_created","field_type":"dimension","group":"CLI","slug":"hubspot|email_send_event_id_created","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_send_event_id_id","field_type":"dimension","group":"CLI","slug":"hubspot|email_send_event_id_id","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"owner_id","field_type":"metric","group":"CLI","slug":"hubspot|owner_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"owner_type","field_type":"dimension","group":"CLI","slug":"hubspot|owner_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"first_name","field_type":"dimension","group":"CLI","slug":"hubspot|first_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"last_name","field_type":"dimension","group":"CLI","slug":"hubspot|last_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email","field_type":"dimension","group":"CLI","slug":"hubspot|email","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"unknown_visitor_conversation","field_type":"dimension","group":"CLI","slug":"hubspot|unknown_visitor_conversation","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"campaign_guid","field_type":"dimension","group":"CLI","slug":"hubspot|campaign_guid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"calendar_event_name","field_type":"dimension","group":"CLI","slug":"hubspot|calendar_event_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"description","field_type":"dimension","group":"CLI","slug":"hubspot|description","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"url","field_type":"dimension","group":"CLI","slug":"hubspot|url","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"created_by","field_type":"metric","group":"CLI","slug":"hubspot|created_by","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"create_content","field_type":"dimension","group":"CLI","slug":"hubspot|create_content","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"preview_key","field_type":"dimension","group":"CLI","slug":"hubspot|preview_key","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"template_path","field_type":"dimension","group":"CLI","slug":"hubspot|template_path","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"social_username","field_type":"dimension","group":"CLI","slug":"hubspot|social_username","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"social_display_name","field_type":"dimension","group":"CLI","slug":"hubspot|social_display_name","taxon_type":"dimension"}]}
-
-        '
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '22795'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Nov 2020 15:12:06 GMT
-      Via:
-      - kong/2.0.3
-      X-Amzn-Trace-Id:
-      - None
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '78'
-      x-diesel-request-id:
-      - b0833ae5-eb65-4d5f-b587-646c219de35a
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - pano-cli/1.2.0
-    method: GET
-    uri: https://diesel.panoramicapi.com/api/v1/federated/taxonomy/taxons?company_slug=panoramic-z5y1clyi&offset=200&limit=100
-  response:
-    body:
-      string: '{"data":[{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"avatar_url","field_type":"dimension","group":"CLI","slug":"hubspot|avatar_url","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"is_recurring","field_type":"dimension","group":"CLI","slug":"hubspot|is_recurring","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"topic_ids","field_type":"dimension","group":"CLI","slug":"hubspot|topic_ids","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"content_group_id","field_type":"dimension","group":"CLI","slug":"hubspot|content_group_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"group_id","field_type":"dimension","group":"CLI","slug":"hubspot|group_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"group_order","field_type":"dimension","group":"CLI","slug":"hubspot|group_order","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"user_ids","field_type":"dimension","group":"CLI","slug":"hubspot|user_ids","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"user_id","field_type":"metric","group":"CLI","slug":"hubspot|user_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"engagement_task_status","field_type":"dimension","group":"CLI","slug":"hubspot|engagement_task_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"for_object_type","field_type":"dimension","group":"CLI","slug":"hubspot|for_object_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"task_type","field_type":"dimension","group":"CLI","slug":"hubspot|task_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"is_all_day","field_type":"dimension","group":"CLI","slug":"hubspot|is_all_day","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"priority","field_type":"dimension","group":"CLI","slug":"hubspot|priority","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"completion_date","field_type":"metric","group":"CLI","slug":"hubspot|completion_date","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"stage_id","field_type":"dimension","group":"CLI","slug":"hubspot|stage_id","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"probability","field_type":"metric","group":"CLI","slug":"hubspot|probability","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"closed_won","field_type":"dimension","group":"CLI","slug":"hubspot|closed_won","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_closed_amount_in_home_currency","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_closed_amount_in_home_currency","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_brand_or_agency_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_brand_or_agency_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_amount_in_home_currency","field_type":"metric","group":"CLI","slug":"hubspot|property_amount_in_home_currency","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_connectors_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_connectors_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_days_to_close","field_type":"metric","group":"CLI","slug":"hubspot|property_days_to_close","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_budget_confirmed_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_budget_confirmed_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_competitor_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_competitor_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_analytics_source","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_source","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_discovery_completed_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_discovery_completed_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_closed_amount","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_closed_amount","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_data_warehouse_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_data_warehouse_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_budget_c","field_type":"metric","group":"CLI","slug":"hubspot|property_budget_c","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_contract_amount_c","field_type":"metric","group":"CLI","slug":"hubspot|property_contract_amount_c","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_billing_terms_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_billing_terms_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_contract_renewal_date_c","field_type":"metric","group":"CLI","slug":"hubspot|property_contract_renewal_date_c","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_contact_s_first_name_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_contact_s_first_name_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_contact_s_last_name_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_contact_s_last_name_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_contact_s_title_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_contact_s_title_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_created_by_user_id","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_created_by_user_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_contract_type_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_contract_type_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_deal_stage_probability","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_deal_stage_probability","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_projected_amount","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_projected_amount","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_lastmodifieddate","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_lastmodifieddate","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_hs_is_closed","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_is_closed","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_projected_amount_in_home_currency","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_projected_amount_in_home_currency","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_salesforceopportunityid","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_salesforceopportunityid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_merged_object_ids","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_merged_object_ids","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_verified_sal_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_verified_sal_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_sal_amount_total_c","field_type":"metric","group":"CLI","slug":"hubspot|property_sal_amount_total_c","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_opportunity_type_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_opportunity_type_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_opportunity_won_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_opportunity_won_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"deal_pipeline_id","field_type":"dimension","group":"CLI","slug":"hubspot|deal_pipeline_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hubspot_owner_assigneddate","field_type":"dimension","group":"CLI","slug":"hubspot|property_hubspot_owner_assigneddate","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_salesforcelastsynctime","field_type":"dimension","group":"CLI","slug":"hubspot|property_salesforcelastsynctime","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_dealname","field_type":"dimension","group":"CLI","slug":"hubspot|property_dealname","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_closedate","field_type":"dimension","group":"CLI","slug":"hubspot|property_closedate","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_referrer_paid_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_referrer_paid_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_sal_recorded_month_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_sal_recorded_month_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_createdate","field_type":"dimension","group":"CLI","slug":"hubspot|property_createdate","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_roi_analysis_completed_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_roi_analysis_completed_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"deal_pipeline_stage_id","field_type":"dimension","group":"CLI","slug":"hubspot|deal_pipeline_stage_id","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_sal_amount_oustanding_c","field_type":"metric","group":"CLI","slug":"hubspot|property_sal_amount_oustanding_c","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_amount","field_type":"metric","group":"CLI","slug":"hubspot|property_amount","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_originator_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_originator_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_sal_amount_paid_c","field_type":"metric","group":"CLI","slug":"hubspot|property_sal_amount_paid_c","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_sal_paid_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_sal_paid_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_loss_reason_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_loss_reason_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_sales_forecast_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_sales_forecast_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_updated_by_user_id","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_updated_by_user_id","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_user_ids_of_all_owners","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_user_ids_of_all_owners","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_referrer_name_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_referrer_name_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_notes_last_updated","field_type":"dimension","group":"CLI","slug":"hubspot|property_notes_last_updated","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_referrer_to_be_paid_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_referrer_to_be_paid_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_referral_amount_unpaid_c","field_type":"metric","group":"CLI","slug":"hubspot|property_referral_amount_unpaid_c","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_payment_terms_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_payment_terms_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_ref_c","field_type":"metric","group":"CLI","slug":"hubspot|property_ref_c","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_referral_amount_paid_c","field_type":"metric","group":"CLI","slug":"hubspot|property_referral_amount_paid_c","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_notes_from_bryan","field_type":"dimension","group":"CLI","slug":"hubspot|property_notes_from_bryan","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_notes_next_steps","field_type":"dimension","group":"CLI","slug":"hubspot|property_notes_next_steps","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_notes_last_contacted","field_type":"dimension","group":"CLI","slug":"hubspot|property_notes_last_contacted","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_sales_email_last_replied","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_sales_email_last_replied","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_latest_meeting_activity","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_latest_meeting_activity","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_dealtype","field_type":"dimension","group":"CLI","slug":"hubspot|property_dealtype","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_createdate","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_createdate","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_all_owner_ids","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_all_owner_ids","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_description","field_type":"dimension","group":"CLI","slug":"hubspot|property_description","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hubspot_team_id","field_type":"metric","group":"CLI","slug":"hubspot|property_hubspot_team_id","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_all_team_ids","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_all_team_ids","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_all_accessible_team_ids","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_all_accessible_team_ids","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_num_notes","field_type":"metric","group":"CLI","slug":"hubspot|property_num_notes","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_num_contacted_notes","field_type":"metric","group":"CLI","slug":"hubspot|property_num_contacted_notes","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_notes_next_activity_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_notes_next_activity_date","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_num_associated_contacts","field_type":"metric","group":"CLI","slug":"hubspot|property_num_associated_contacts","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_analytics_first_timestamp","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_first_timestamp","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_num_contacts_with_buying_roles","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_num_contacts_with_buying_roles","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_name","field_type":"dimension","group":"CLI","slug":"hubspot|property_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_linkedinbio","field_type":"dimension","group":"CLI","slug":"hubspot|property_linkedinbio","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_founded_year","field_type":"metric","group":"CLI","slug":"hubspot|property_founded_year","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_timezone","field_type":"dimension","group":"CLI","slug":"hubspot|property_timezone","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_total_money_raised","field_type":"dimension","group":"CLI","slug":"hubspot|property_total_money_raised","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_city","field_type":"dimension","group":"CLI","slug":"hubspot|property_city","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_analytics_num_page_views","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_analytics_num_page_views","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_num_decision_makers","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_num_decision_makers","taxon_type":"metric"}]}
-
-        '
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '24900'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Nov 2020 15:12:06 GMT
-      Via:
-      - kong/2.0.3
-      X-Amzn-Trace-Id:
-      - None
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '84'
-      x-diesel-request-id:
-      - ed3c5e2d-51ad-4e50-b185-9f2c8b94a54b
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - pano-cli/1.2.0
-    method: GET
-    uri: https://diesel.panoramicapi.com/api/v1/federated/taxonomy/taxons?company_slug=panoramic-z5y1clyi&offset=300&limit=100
-  response:
-    body:
-      string: '{"data":[{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_panoramic_client_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_panoramic_client_c","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_num_open_deals","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_num_open_deals","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_salesforceaccountid","field_type":"dimension","group":"CLI","slug":"hubspot|property_salesforceaccountid","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_num_blockers","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_num_blockers","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_facebook_company_page","field_type":"dimension","group":"CLI","slug":"hubspot|property_facebook_company_page","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_analytics_num_visits","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_analytics_num_visits","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_operam_client_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_operam_client_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_address","field_type":"dimension","group":"CLI","slug":"hubspot|property_address","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_current_client_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_current_client_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_linkedin_company_page","field_type":"dimension","group":"CLI","slug":"hubspot|property_linkedin_company_page","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_total_deal_value","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_total_deal_value","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_target_account_probability","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_target_account_probability","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_is_public","field_type":"dimension","group":"CLI","slug":"hubspot|property_is_public","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_twitterhandle","field_type":"dimension","group":"CLI","slug":"hubspot|property_twitterhandle","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_account_number_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_account_number_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_phone","field_type":"dimension","group":"CLI","slug":"hubspot|property_phone","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_lead_number_c","field_type":"metric","group":"CLI","slug":"hubspot|property_lead_number_c","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_address_2","field_type":"dimension","group":"CLI","slug":"hubspot|property_address_2","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_lfapp_view_in_leadfeeder","field_type":"dimension","group":"CLI","slug":"hubspot|property_lfapp_view_in_leadfeeder","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_num_associated_deals","field_type":"metric","group":"CLI","slug":"hubspot|property_num_associated_deals","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_first_deal_created_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_first_deal_created_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_analytics_last_visit_timestamp","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_last_visit_timestamp","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_analytics_first_visit_timestamp","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_first_visit_timestamp","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_analytics_last_timestamp","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_last_timestamp","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_last_booked_meeting_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_last_booked_meeting_date","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_num_conversion_events","field_type":"metric","group":"CLI","slug":"hubspot|property_num_conversion_events","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_first_conversion_event_name","field_type":"dimension","group":"CLI","slug":"hubspot|property_first_conversion_event_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_recent_conversion_event_name","field_type":"dimension","group":"CLI","slug":"hubspot|property_recent_conversion_event_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_recent_conversion_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_recent_conversion_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_first_conversion_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_first_conversion_date","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_total_revenue","field_type":"metric","group":"CLI","slug":"hubspot|property_total_revenue","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_recent_deal_close_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_recent_deal_close_date","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_recent_deal_amount","field_type":"metric","group":"CLI","slug":"hubspot|property_recent_deal_amount","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_media_spend_c","field_type":"metric","group":"CLI","slug":"hubspot|property_media_spend_c","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_last_open_task_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_last_open_task_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_lfapp_latest_visit","field_type":"dimension","group":"CLI","slug":"hubspot|property_lfapp_latest_visit","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_salesforcedeleted","field_type":"dimension","group":"CLI","slug":"hubspot|property_salesforcedeleted","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_last_sales_activity_timestamp","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_last_sales_activity_timestamp","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_last_sales_activity_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_last_sales_activity_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_last_logged_call_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_last_logged_call_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_domain","field_type":"dimension","group":"CLI","slug":"hubspot|property_domain","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_industry","field_type":"dimension","group":"CLI","slug":"hubspot|property_industry","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_zip","field_type":"dimension","group":"CLI","slug":"hubspot|property_zip","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_website","field_type":"dimension","group":"CLI","slug":"hubspot|property_website","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_state","field_type":"dimension","group":"CLI","slug":"hubspot|property_state","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_web_technologies","field_type":"dimension","group":"CLI","slug":"hubspot|property_web_technologies","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_country","field_type":"dimension","group":"CLI","slug":"hubspot|property_country","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hubspot_owner_id","field_type":"metric","group":"CLI","slug":"hubspot|property_hubspot_owner_id","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_annualrevenue","field_type":"metric","group":"CLI","slug":"hubspot|property_annualrevenue","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_first_contact_createdate","field_type":"dimension","group":"CLI","slug":"hubspot|property_first_contact_createdate","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_numberofemployees","field_type":"metric","group":"CLI","slug":"hubspot|property_numberofemployees","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_type","field_type":"dimension","group":"CLI","slug":"hubspot|property_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_lifecyclestage","field_type":"dimension","group":"CLI","slug":"hubspot|property_lifecyclestage","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_num_child_companies","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_num_child_companies","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_analytics_last_touch_converting_campaign","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_last_touch_converting_campaign","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_analytics_first_touch_converting_campaign","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_first_touch_converting_campaign","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"obsoleted_by_id","field_type":"dimension","group":"CLI","slug":"hubspot|obsoleted_by_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"obsoleted_by_created","field_type":"dimension","group":"CLI","slug":"hubspot|obsoleted_by_created","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"browser","field_type":"dimension","group":"CLI","slug":"hubspot|browser","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"location","field_type":"dimension","group":"CLI","slug":"hubspot|location","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"referer","field_type":"dimension","group":"CLI","slug":"hubspot|referer","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_subscription_name","field_type":"dimension","group":"CLI","slug":"hubspot|email_subscription_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_event_bounce_id","field_type":"dimension","group":"CLI","slug":"hubspot|email_event_bounce_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"response","field_type":"dimension","group":"CLI","slug":"hubspot|response","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_event_bounce_status","field_type":"dimension","group":"CLI","slug":"hubspot|email_event_bounce_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_event_sent_id","field_type":"dimension","group":"CLI","slug":"hubspot|email_event_sent_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"from","field_type":"dimension","group":"CLI","slug":"hubspot|from","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"reply_to","field_type":"dimension","group":"CLI","slug":"hubspot|reply_to","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"cc","field_type":"dimension","group":"CLI","slug":"hubspot|cc","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"bcc","field_type":"dimension","group":"CLI","slug":"hubspot|bcc","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"canonical_vid","field_type":"metric","group":"CLI","slug":"hubspot|canonical_vid","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"merged_vids","field_type":"dimension","group":"CLI","slug":"hubspot|merged_vids","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"profile_url","field_type":"dimension","group":"CLI","slug":"hubspot|profile_url","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_assistant_email_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_assistant_email_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_assistant_s_first_name_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_assistant_s_first_name_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_assistant_s_last_name_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_assistant_s_last_name_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_company_size","field_type":"dimension","group":"CLI","slug":"hubspot|property_company_size","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_customer_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_customer_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_data_source_1","field_type":"dimension","group":"CLI","slug":"hubspot|property_data_source_1","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_data_source_2","field_type":"dimension","group":"CLI","slug":"hubspot|property_data_source_2","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_date_of_birth","field_type":"dimension","group":"CLI","slug":"hubspot|property_date_of_birth","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_degree","field_type":"dimension","group":"CLI","slug":"hubspot|property_degree","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_detail_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_detail_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_email_bounced_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_email_bounced_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_field_of_study","field_type":"dimension","group":"CLI","slug":"hubspot|property_field_of_study","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_form_offer","field_type":"dimension","group":"CLI","slug":"hubspot|property_form_offer","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_full_name","field_type":"dimension","group":"CLI","slug":"hubspot|property_full_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_gender","field_type":"dimension","group":"CLI","slug":"hubspot|property_gender","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_graduation_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_graduation_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_avatar_filemanager_key","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_avatar_filemanager_key","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_buying_role","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_buying_role","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_content_membership_notes","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_content_membership_notes","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_content_membership_registration_domain_sent_to","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_content_membership_registration_domain_sent_to","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_content_membership_status","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_content_membership_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_conversations_visitor_email","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_conversations_visitor_email","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_email_hard_bounce_reason","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_hard_bounce_reason","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_email_hard_bounce_reason_enum","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_hard_bounce_reason_enum","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_email_quarantined_reason","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_quarantined_reason","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_emailconfirmationstatus","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_emailconfirmationstatus","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_facebook_click_id","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_facebook_click_id","taxon_type":"dimension"}]}
-
-        '
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '24226'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Nov 2020 15:12:07 GMT
-      Via:
-      - kong/2.0.3
-      X-Amzn-Trace-Id:
-      - None
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '73'
-      x-diesel-request-id:
-      - 949f0285-afc8-4adc-a7ce-e2aac27fbc00
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - pano-cli/1.2.0
-    method: GET
-    uri: https://diesel.panoramicapi.com/api/v1/federated/taxonomy/taxons?company_slug=panoramic-z5y1clyi&offset=400&limit=100
-  response:
-    body:
-      string: '{"data":[{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_facebookid","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_facebookid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_feedback_last_nps_follow_up","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_feedback_last_nps_follow_up","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_feedback_last_nps_rating","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_feedback_last_nps_rating","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_first_engagement_descr","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_first_engagement_descr","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_first_engagement_object_type","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_first_engagement_object_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_google_click_id","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_google_click_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_googleplusid","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_googleplusid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_ip_timezone","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_ip_timezone","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_lead_status","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_lead_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_legal_basis","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_legal_basis","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_linkedinid","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_linkedinid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_marketable_reason_id","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_marketable_reason_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_marketable_reason_type","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_marketable_reason_type","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_marketable_status","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_marketable_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_marketable_until_renewal","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_marketable_until_renewal","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_predictivescoringtier","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_predictivescoringtier","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_twitterid","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_twitterid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_ip_city","field_type":"dimension","group":"CLI","slug":"hubspot|property_ip_city","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_ip_country","field_type":"dimension","group":"CLI","slug":"hubspot|property_ip_country","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_ip_country_code","field_type":"dimension","group":"CLI","slug":"hubspot|property_ip_country_code","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_ip_latlon","field_type":"dimension","group":"CLI","slug":"hubspot|property_ip_latlon","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_ip_state","field_type":"dimension","group":"CLI","slug":"hubspot|property_ip_state","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_ip_state_code","field_type":"dimension","group":"CLI","slug":"hubspot|property_ip_state_code","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_ip_zipcode","field_type":"dimension","group":"CLI","slug":"hubspot|property_ip_zipcode","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_job_function","field_type":"dimension","group":"CLI","slug":"hubspot|property_job_function","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_job_level","field_type":"dimension","group":"CLI","slug":"hubspot|property_job_level","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_lead_notes_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_lead_notes_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_leadsource","field_type":"dimension","group":"CLI","slug":"hubspot|property_leadsource","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_leadstatus","field_type":"dimension","group":"CLI","slug":"hubspot|property_leadstatus","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_linkedin_profile_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_linkedin_profile_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_marital_status","field_type":"dimension","group":"CLI","slug":"hubspot|property_marital_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_marketer_or_agency_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_marketer_or_agency_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_military_status","field_type":"dimension","group":"CLI","slug":"hubspot|property_military_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_multiple_company_divisions_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_multiple_company_divisions_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_operam_account_lead_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_operam_account_lead_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_opportunitytype_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_opportunitytype_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_persona_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_persona_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_platform_user_type_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_platform_user_type_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_rating","field_type":"dimension","group":"CLI","slug":"hubspot|property_rating","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_referral_origin_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_referral_origin_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_referrer_company_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_referrer_company_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_relationship_status","field_type":"dimension","group":"CLI","slug":"hubspot|property_relationship_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_salesforcecampaignids","field_type":"dimension","group":"CLI","slug":"hubspot|property_salesforcecampaignids","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_salesforcecontactid","field_type":"dimension","group":"CLI","slug":"hubspot|property_salesforcecontactid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_salesforceleadid","field_type":"dimension","group":"CLI","slug":"hubspot|property_salesforceleadid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_salesforceopportunitystage","field_type":"dimension","group":"CLI","slug":"hubspot|property_salesforceopportunitystage","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_salesforceownerid","field_type":"dimension","group":"CLI","slug":"hubspot|property_salesforceownerid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_school","field_type":"dimension","group":"CLI","slug":"hubspot|property_school","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_seniority","field_type":"dimension","group":"CLI","slug":"hubspot|property_seniority","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_sfcampaignid","field_type":"dimension","group":"CLI","slug":"hubspot|property_sfcampaignid","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_source_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_source_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_stage_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_stage_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_start_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_start_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_submitterip_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_submitterip_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_type_of_media_relationship_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_type_of_media_relationship_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_unbouncepageid_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_unbouncepageid_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_unbouncepagevariant_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_unbouncepagevariant_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_unbouncesubmissiondate_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_unbouncesubmissiondate_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_unbouncesubmissiontime_c","field_type":"dimension","group":"CLI","slug":"hubspot|property_unbouncesubmissiontime_c","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_utm_campaign","field_type":"dimension","group":"CLI","slug":"hubspot|property_utm_campaign","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_utm_medium","field_type":"dimension","group":"CLI","slug":"hubspot|property_utm_medium","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_utm_source","field_type":"dimension","group":"CLI","slug":"hubspot|property_utm_source","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_utm_term","field_type":"dimension","group":"CLI","slug":"hubspot|property_utm_term","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_want_demo","field_type":"dimension","group":"CLI","slug":"hubspot|property_want_demo","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_work_email","field_type":"dimension","group":"CLI","slug":"hubspot|property_work_email","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_firstname","field_type":"dimension","group":"CLI","slug":"hubspot|property_firstname","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_analytics_first_url","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_first_url","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_email_optout_7903713","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_optout_7903713","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_email_optout_9573350","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_optout_9573350","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_currentlyinworkflow","field_type":"dimension","group":"CLI","slug":"hubspot|property_currentlyinworkflow","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_analytics_last_url","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_last_url","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_lastname","field_type":"dimension","group":"CLI","slug":"hubspot|property_lastname","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_salutation","field_type":"dimension","group":"CLI","slug":"hubspot|property_salutation","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_twitterprofilephoto","field_type":"dimension","group":"CLI","slug":"hubspot|property_twitterprofilephoto","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_persona","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_persona","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_mobilephone","field_type":"dimension","group":"CLI","slug":"hubspot|property_mobilephone","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_fax","field_type":"dimension","group":"CLI","slug":"hubspot|property_fax","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_email_last_email_name","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_last_email_name","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_engagements_last_meeting_booked_campaign","field_type":"dimension","group":"CLI","slug":"hubspot|property_engagements_last_meeting_booked_campaign","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_engagements_last_meeting_booked_medium","field_type":"dimension","group":"CLI","slug":"hubspot|property_engagements_last_meeting_booked_medium","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_engagements_last_meeting_booked_source","field_type":"dimension","group":"CLI","slug":"hubspot|property_engagements_last_meeting_booked_source","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_owneremail","field_type":"dimension","group":"CLI","slug":"hubspot|property_owneremail","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_ownername","field_type":"dimension","group":"CLI","slug":"hubspot|property_ownername","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_twitterbio","field_type":"dimension","group":"CLI","slug":"hubspot|property_twitterbio","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_language","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_language","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_analytics_first_referrer","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_first_referrer","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_jobtitle","field_type":"dimension","group":"CLI","slug":"hubspot|property_jobtitle","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_photo","field_type":"dimension","group":"CLI","slug":"hubspot|property_photo","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_analytics_last_referrer","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_analytics_last_referrer","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_message","field_type":"dimension","group":"CLI","slug":"hubspot|property_message","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_company","field_type":"dimension","group":"CLI","slug":"hubspot|property_company","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_numemployees","field_type":"dimension","group":"CLI","slug":"hubspot|property_numemployees","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_predictivecontactscorebucket","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_predictivecontactscorebucket","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_analytics_revenue","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_analytics_revenue","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_hs_email_quarantined","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_quarantined","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_hs_is_unworked","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_is_unworked","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_analytics_average_page_views","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_analytics_average_page_views","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_associatedcompanyid","field_type":"metric","group":"CLI","slug":"hubspot|property_associatedcompanyid","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_analytics_num_event_completions","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_analytics_num_event_completions","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_social_facebook_clicks","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_social_facebook_clicks","taxon_type":"metric"}]}
-
-        '
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '23716'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Nov 2020 15:12:07 GMT
-      Via:
-      - kong/2.0.3
-      X-Amzn-Trace-Id:
-      - None
-      X-Kong-Proxy-Latency:
-      - '0'
-      X-Kong-Upstream-Latency:
-      - '89'
-      x-diesel-request-id:
-      - 906788d5-d003-47cb-9d0b-ee8278916205
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - pano-cli/1.2.0
-    method: GET
-    uri: https://diesel.panoramicapi.com/api/v1/federated/taxonomy/taxons?company_slug=panoramic-z5y1clyi&offset=500&limit=100
-  response:
-    body:
-      string: '{"data":[{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_social_last_engagement","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_social_last_engagement","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_social_google_plus_clicks","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_social_google_plus_clicks","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_social_linkedin_clicks","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_social_linkedin_clicks","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_lastmodifieddate","field_type":"dimension","group":"CLI","slug":"hubspot|property_lastmodifieddate","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_hs_email_optout","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_optout","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_social_num_broadcast_clicks","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_social_num_broadcast_clicks","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_lifecyclestage_lead_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_lifecyclestage_lead_date","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_social_twitter_clicks","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_social_twitter_clicks","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_email_first_send_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_first_send_date","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_email_delivered","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_email_delivered","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_email_first_open_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_first_open_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_email_last_send_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_last_send_date","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_email_sends_since_last_engagement","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_email_sends_since_last_engagement","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_email_open","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_email_open","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_email_last_open_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_last_open_date","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_email_bounce","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_email_bounce","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_email_first_click_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_first_click_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_email_last_click_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_last_click_date","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_email_click","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_email_click","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_lifecyclestage_other_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_lifecyclestage_other_date","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_time_to_first_engagement","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_time_to_first_engagement","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_lifecyclestage_opportunity_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_lifecyclestage_opportunity_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_hs_facebook_ad_clicked","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_facebook_ad_clicked","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_lifecyclestage_subscriber_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_lifecyclestage_subscriber_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_hs_email_bad_address","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_bad_address","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"property_hs_first_engagement_object_id","field_type":"metric","group":"CLI","slug":"hubspot|property_hs_first_engagement_object_id","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"boolean","description":null,"display_name":"property_hs_created_by_conversations","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_created_by_conversations","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_sales_email_last_opened","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_sales_email_last_opened","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_sa_first_engagement_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_sa_first_engagement_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_facebook_lead_id","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_facebook_lead_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_marketing_pain_point","field_type":"dimension","group":"CLI","slug":"hubspot|property_marketing_pain_point","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_what_benefit_would_help_your_marketing_team_the_most_right_now_","field_type":"dimension","group":"CLI","slug":"hubspot|property_what_benefit_would_help_your_marketing_team_the_most_right_now_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_what_industry_are_you_in_","field_type":"dimension","group":"CLI","slug":"hubspot|property_what_industry_are_you_in_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_what_is_your_biggest_marketing_pain_point_","field_type":"dimension","group":"CLI","slug":"hubspot|property_what_is_your_biggest_marketing_pain_point_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_what_is_your_role_on_the_team_","field_type":"dimension","group":"CLI","slug":"hubspot|property_what_is_your_role_on_the_team_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_role","field_type":"dimension","group":"CLI","slug":"hubspot|property_role","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_department","field_type":"dimension","group":"CLI","slug":"hubspot|property_department","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_how_do_you_currently_store_your_marketing_data_","field_type":"dimension","group":"CLI","slug":"hubspot|property_how_do_you_currently_store_your_marketing_data_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_how_long_does_it_take_to_group_map_and_model_all_of_your_data_","field_type":"dimension","group":"CLI","slug":"hubspot|property_how_long_does_it_take_to_group_map_and_model_all_of_your_data_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_does_your_marketing_or_analytics_team_want_to_do_any_of_the_following_","field_type":"dimension","group":"CLI","slug":"hubspot|property_does_your_marketing_or_analytics_team_want_to_do_any_of_the_following_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_how_do_you_currently_pull_or_extract_your_marketing_data_","field_type":"dimension","group":"CLI","slug":"hubspot|property_how_do_you_currently_pull_or_extract_your_marketing_data_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_how_do_you_store_your_marketing_data_","field_type":"dimension","group":"CLI","slug":"hubspot|property_how_do_you_store_your_marketing_data_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_what_part_do_you_play_on_the_team_","field_type":"dimension","group":"CLI","slug":"hubspot|property_what_part_do_you_play_on_the_team_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_how_long_does_it_take_you_to_group_map_and_model_your_data_","field_type":"dimension","group":"CLI","slug":"hubspot|property_how_long_does_it_take_you_to_group_map_and_model_your_data_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_how_do_you_currently_extract_or_pull_marketing_data_","field_type":"dimension","group":"CLI","slug":"hubspot|property_how_do_you_currently_extract_or_pull_marketing_data_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_would_you_like_to_take_a_quiz_to_see_how_panoramic_can_help_you_","field_type":"dimension","group":"CLI","slug":"hubspot|property_would_you_like_to_take_a_quiz_to_see_how_panoramic_can_help_you_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_what_is_your_industry_","field_type":"dimension","group":"CLI","slug":"hubspot|property_what_is_your_industry_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_would_you_like_to_do_any_of_the_following_","field_type":"dimension","group":"CLI","slug":"hubspot|property_would_you_like_to_do_any_of_the_following_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_ok_well_let_s_at_least_stay_in_touch_","field_type":"dimension","group":"CLI","slug":"hubspot|property_ok_well_let_s_at_least_stay_in_touch_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_forrester_paper","field_type":"dimension","group":"CLI","slug":"hubspot|property_forrester_paper","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"email_event_dropped_id","field_type":"dimension","group":"CLI","slug":"hubspot|email_event_dropped_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"drop_reason","field_type":"dimension","group":"CLI","slug":"hubspot|drop_reason","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"drop_message","field_type":"dimension","group":"CLI","slug":"hubspot|drop_message","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"facebook_ads|actions__offsite_conversion_fb_pixel_complete_registration_value
-        ","data_type":"numeric","description":"The number of invites scheduled with
-        Sales.","display_format":"decimal_0","display_name":"Calendy Invites","field_type":"metric","group":"Custom","slug":"calendy_invites","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"fivetran_audit_id","field_type":"dimension","group":"CLI","slug":"hubspot|fivetran_audit_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"message","field_type":"dimension","group":"CLI","slug":"hubspot|message","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"update_started","field_type":"dimension","group":"CLI","slug":"hubspot|update_started","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"update_id","field_type":"dimension","group":"CLI","slug":"hubspot|update_id","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"schema","field_type":"dimension","group":"CLI","slug":"hubspot|schema","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"table","field_type":"dimension","group":"CLI","slug":"hubspot|table","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"start","field_type":"dimension","group":"CLI","slug":"hubspot|start","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"done","field_type":"dimension","group":"CLI","slug":"hubspot|done","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_name":"rows_updated_or_inserted","field_type":"metric","group":"CLI","slug":"hubspot|rows_updated_or_inserted","taxon_type":"metric"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"fivetran_audit_status","field_type":"dimension","group":"CLI","slug":"hubspot|fivetran_audit_status","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"progress","field_type":"dimension","group":"CLI","slug":"hubspot|progress","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_format":null,"display_name":"Last
-        Activity","field_type":"dimension","group":"CLI","slug":"hubspot|metadata_last_processing_state_change_at","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"concat(adwords|headline_1,\"
-        \" ,\"|\",\" \",adwords|headline_2  )","data_type":"text","description":"Combination
-        of Google Ads Headline 1 and Headline 2 field","display_format":"decimal_2","display_name":"Google
-        Ads Headline Concatenation ","field_type":"dimension","group":"Custom","slug":"google_ads_headline_concatenation","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"checkout_initiated
-        ","data_type":"numeric","description":"Showtime lookup click","display_format":"decimal_0","display_name":"Showtime
-        Lookup","field_type":"metric","group":"Custom","slug":"showtime_lookup","taxon_type":"metric"},{"aggregation":{"type":"avg"},"aggregation_type":"avg","calculation":"spend
-        /panoramic_z5y1clyi__leads_custom ","data_type":"money","description":"Cost
-        per Lead (Lead forms submitted on Pano Landing Page)","display_format":"usd_2","display_name":"CPL
-        (Pano LP)","field_type":"metric","group":"Custom","slug":"cpl_pano_lp","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"parse(merge(?facebook_ads|ad_name,?appnexus|creative_name,?linkedin|creative_id),\"_\",4)","data_type":"text","description":"DNU
-        TEST","display_format":"decimal_2","display_name":"Pano Ad Name 2","field_type":"dimension","group":"Custom","slug":"pano_ad_name_2","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"upper(parse(adwords|campaign_name,\"-\",2))","data_type":"text","description":"Parse.
-        Google Search Only. Campaign type (e.g. Branded or Non Branded) parsed from
-        the naming convention.","display_format":"decimal_2","display_name":"Campaign
-        Type (Part 1)","field_type":"dimension","group":"Custom","slug":"campaign_type","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"parse(adwords|campaign_name,\"-\",4)","data_type":"text","description":"Parse.
-        Google Search Only. Targeted non-brand terms parsed from the naming convention.","display_format":"decimal_2","display_name":"Targeting","field_type":"dimension","group":"Custom","slug":"targeting_1","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_would_you_like_to_see_a_demo_","field_type":"dimension","group":"CLI","slug":"hubspot|property_would_you_like_to_see_a_demo_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_where_are_you_spending_the_majority_your_time_","field_type":"dimension","group":"CLI","slug":"hubspot|property_where_are_you_spending_the_majority_your_time_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_magic_wand","field_type":"dimension","group":"CLI","slug":"hubspot|property_magic_wand","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_if_you_had_a_magic_wand_how_would_you_empower_your_marketing_and_analytics_teams_today_","field_type":"dimension","group":"CLI","slug":"hubspot|property_if_you_had_a_magic_wand_how_would_you_empower_your_marketing_and_analytics_teams_today_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_how_long_does_it_take_your_team_to_group_map_and_model_your_data_","field_type":"dimension","group":"CLI","slug":"hubspot|property_how_long_does_it_take_your_team_to_group_map_and_model_your_data_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_how_do_you_currently_collect_and_store_your_marketing_data_","field_type":"dimension","group":"CLI","slug":"hubspot|property_how_do_you_currently_collect_and_store_your_marketing_data_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_how_do_you_currently_collect_and_store_marketing_data_","field_type":"dimension","group":"CLI","slug":"hubspot|property_how_do_you_currently_collect_and_store_marketing_data_","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_lifecyclestage_customer_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_lifecyclestage_customer_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_hs_email_customer_quarantined_reason","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_email_customer_quarantined_reason","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_sales_email_last_clicked","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_sales_email_last_clicked","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_job_role","field_type":"dimension","group":"CLI","slug":"hubspot|property_job_role","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_title","field_type":"dimension","group":"CLI","slug":"hubspot|property_title","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_lifecyclestage_salesqualifiedlead_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_lifecyclestage_salesqualifiedlead_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"datetime","description":null,"display_name":"property_hs_lifecyclestage_marketingqualifiedlead_date","field_type":"dimension","group":"CLI","slug":"hubspot|property_hs_lifecyclestage_marketingqualifiedlead_date","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_panoramic_lifecycle_stage","field_type":"dimension","group":"CLI","slug":"hubspot|property_panoramic_lifecycle_stage","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_what_industry_do_you_work_in","field_type":"dimension","group":"CLI","slug":"hubspot|property_what_industry_do_you_work_in","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_what_is_your_job_title","field_type":"dimension","group":"CLI","slug":"hubspot|property_what_is_your_job_title","taxon_type":"dimension"},{"calculation":null,"data_source":"hubspot","data_type":"text","description":null,"display_name":"property_what_is_your_job_role","field_type":"dimension","group":"CLI","slug":"hubspot|property_what_is_your_job_role","taxon_type":"dimension"},{"aggregation":{"type":"avg"},"aggregation_type":"avg","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_format":"decimal_0","display_name":"Implicit
-        Score","field_type":"metric","group":"CLI","slug":"hubspot|property_implicit_score","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"hubspot","data_type":"numeric","description":null,"display_format":"decimal_2","display_name":"Explicit
-        Score","field_type":"metric","group":"CLI","slug":"hubspot|property_contact_score","taxon_type":"metric"},{"aggregation":{"type":"avg"},"aggregation_type":"avg","calculation":"panoramic_z5y1clyi__leads_custom
-        /panoramic_z5y1clyi__clicks_to_lp ","data_type":"percent","description":"Total
-        Lead Forms Submitted divided by Total Clicks to Landing Page","display_format":"percent_2","display_name":"Lead
-        Rate (Clicks to LP)","field_type":"metric","group":"Custom","slug":"lead_rate_clicks_to_lp","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"merge(?facebook_ads|ad_name,?appnexus|creative_name,?linkedin|creative_id)","data_type":"text","description":"Custom
-        Pano Ad Name Blending across Platforms","display_format":"decimal_2","display_name":"Pano
-        Ad Name","field_type":"dimension","group":"Custom","slug":"pano_ad_name","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"parse(panoramic_z5y1clyi__pano_ad_name
-        , ''_'', 6)","data_type":"text","description":"Parsed: Landing Page from Pano
-        Ad Name","display_format":"decimal_2","display_name":"Ad Landing Page","field_type":"dimension","group":"Custom","slug":"ad_landing_page","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"checkout_initiated
-        + twitter|conversion_purchases_metric + snapchat|conversion_purchases + conversions","data_type":"numeric","description":"Sacha''s
-        Conversions (twitter, snap, FB)","display_format":"decimal_0","display_name":"Sacha''s
-        Conversions","field_type":"metric","group":"Custom","slug":"sacha_s_conversions","taxon_type":"metric"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"parse(panoramic_z5y1clyi__pano_ad_name,\"_\",4)","data_type":"text","description":"Parsed:
-        Creative Name from Pano Ad Name","display_format":"decimal_2","display_name":"Creative
-        Name","field_type":"dimension","group":"Custom","slug":"creative_name","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"upper(parse(adwords|campaign_name,\"-\",3))","data_type":"text","description":"Google
-        Search Only. Campaign type (e.g. Branded or Non Branded) parsed from the naming
-        convention.","display_format":"decimal_2","display_name":"Campaign Type (Part
-        2)","field_type":"dimension","group":"Custom","slug":"targeting","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"merge(?facebook_ads|platform_position,?linkedin|campaign_type,?adwords|ad_group_type,?appnexus|creative_type)","data_type":"text","description":"Pano
-        custom blending of Ad Placement and Type","display_format":"decimal_2","display_name":"Placement/Type","field_type":"dimension","group":"Custom","slug":"ad_placement_type","taxon_type":"dimension"},{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"panoramic_z5y1clyi_v_d_s_hubspot|property_implicit_score
-        + panoramic_z5y1clyi_v_d_s_hubspot|property_contact_score ","data_type":"numeric","description":null,"display_format":"decimal_2","display_name":"MQL","field_type":"metric","group":"Custom","slug":"mql","taxon_type":"metric"}]}
-
-        '
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '28110'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Nov 2020 15:12:08 GMT
-      Via:
-      - kong/2.0.3
-      X-Amzn-Trace-Id:
-      - None
-      X-Kong-Proxy-Latency:
-      - '0'
-      X-Kong-Upstream-Latency:
-      - '101'
-      x-diesel-request-id:
-      - 4d3a4966-78bf-4e06-85e8-f47618d0f9c0
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - pano-cli/1.2.0
-    method: GET
-    uri: https://diesel.panoramicapi.com/api/v1/federated/taxonomy/taxons?company_slug=panoramic-z5y1clyi&offset=600&limit=100
-  response:
-    body:
-      string: '{"data":[{"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":"sumiff(objective_normalized
-        == \"Video Views\" ,impressions_viewed , 0)","data_type":"numeric","description":null,"display_format":"decimal_2","display_name":"Max''s
-        Viewable Impressions","field_type":"metric","group":"Custom","slug":"max_s_viewable_impressions","taxon_type":"metric"}]}
-
-        '
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '366'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Nov 2020 15:12:08 GMT
-      Via:
-      - kong/2.0.3
-      X-Amzn-Trace-Id:
-      - None
-      X-Kong-Proxy-Latency:
-      - '0'
-      X-Kong-Upstream-Latency:
-      - '44'
-      x-diesel-request-id:
-      - 89bbf22c-f3a2-49bb-81ce-7db54a29e00f
+      - 9d878dac-ad9a-4877-b665-1a32b46f525b
     status:
       code: 200
       message: OK
@@ -2250,7 +1271,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded;charset=UTF-8
       User-Agent:
-      - pano-cli/1.2.0
+      - pano-cli/1.4.0
     method: POST
     uri: https://id.panoramichq.com/oauth2/auscsj124wDoFObOJ4x6/v1/token
   response:
@@ -2263,7 +1284,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 02 Nov 2020 15:12:09 GMT
+      - Fri, 20 Nov 2020 11:28:57 GMT
       Keep-Alive:
       - timeout=5, max=100
       Server:
@@ -2284,17 +1305,124 @@ interactions:
       - no-cache
       set-cookie:
       - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
-      - JSESSIONID=BD492F58AD080F6E99A315460B050D16; Path=/; Secure; HttpOnly
+      - JSESSIONID=3D9E4568E713154F85752D0B380E17CB; Path=/; Secure; HttpOnly
       x-content-type-options:
       - nosniff
       x-okta-request-id:
-      - X6Ahybf4wRUmbEPVMqnpawAABbs
+      - X7eoeWkTre1rLfS@c65gvgAAA2I
       x-rate-limit-limit:
       - '1200'
       x-rate-limit-remaining:
-      - '1195'
+      - '1178'
       x-rate-limit-reset:
-      - '1604329968'
+      - '1605871743'
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - pano-cli/1.4.0
+    method: GET
+    uri: https://diesel.panoramicapi.com/api/v1/federated/taxonomy/taxons?company_slug=panoramic-cli-e2e-c2m6qp4u&offset=0&limit=100
+  response:
+    body:
+      string: '{"data":[{"acronym":null,"aggregation":{"type":"group_by"},"aggregation_type":"group_by","calculation":"2
+        + 2","data_type":"text","description":null,"display_format":null,"display_name":"Company
+        test field","field_type":"dimension","group":"Custom","slug":"company_test_field","taxon_type":"dimension","validation_type":"text"},{"acronym":null,"aggregation":{"type":"sum"},"aggregation_type":"sum","calculation":null,"data_source":"test_dataset","data_type":"text","description":null,"display_format":null,"display_name":"Dataset
+        test field","field_type":"metric","group":"Custom","slug":"test_dataset|dataset_test_field","taxon_type":"metric","validation_type":"text"}]}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '672'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 20 Nov 2020 11:28:58 GMT
+      Via:
+      - kong/2.0.3
+      X-Amzn-Trace-Id:
+      - None
+      X-Kong-Proxy-Latency:
+      - '0'
+      X-Kong-Upstream-Latency:
+      - '53'
+      x-diesel-request-id:
+      - e7ac83da-dee3-41e9-9159-c061cb00c051
+    status:
+      code: 200
+      message: OK
+- request:
+    body: grant_type=client_credentials&scope=platform
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      User-Agent:
+      - pano-cli/1.4.0
+    method: POST
+    uri: https://id.panoramichq.com/oauth2/auscsj124wDoFObOJ4x6/v1/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": 3600, "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+        "scope": "platform"}'
+    headers:
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Fri, 20 Nov 2020 11:28:58 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      cache-control:
+      - no-cache, no-store
+      expires:
+      - '0'
+      p3p:
+      - CP="HONK"
+      pragma:
+      - no-cache
+      set-cookie:
+      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      - JSESSIONID=437BA82DE12F925C18A9063C92EAFF2C; Path=/; Secure; HttpOnly
+      x-content-type-options:
+      - nosniff
+      x-okta-request-id:
+      - X7eoeldVotJXe8R3MDDMsAAABaI
+      x-rate-limit-limit:
+      - '1200'
+      x-rate-limit-remaining:
+      - '1177'
+      x-rate-limit-reset:
+      - '1605871743'
       x-xss-protection:
       - '0'
     status:
@@ -2312,9 +1440,9 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - pano-cli/1.2.0
+      - pano-cli/1.4.0
     method: DELETE
-    uri: https://diesel.panoramicapi.com/api/v1/federated/virtual-data-source/test_dataset?company_slug=panoramic-z5y1clyi
+    uri: https://diesel.panoramicapi.com/api/v1/federated/virtual-data-source/test_dataset?company_slug=panoramic-cli-e2e-c2m6qp4u
   response:
     body:
       string: ''
@@ -2324,7 +1452,7 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Mon, 02 Nov 2020 15:12:11 GMT
+      - Fri, 20 Nov 2020 11:28:59 GMT
       Via:
       - kong/2.0.3
       X-Amzn-Trace-Id:
@@ -2332,9 +1460,9 @@ interactions:
       X-Kong-Proxy-Latency:
       - '1'
       X-Kong-Upstream-Latency:
-      - '37'
+      - '41'
       x-diesel-request-id:
-      - 1d684c12-375a-4636-87f5-e636a7cca4a8
+      - f97e2a93-37d6-4f09-96e2-3304d25d1893
     status:
       code: 204
       message: NO CONTENT
@@ -2352,7 +1480,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded;charset=UTF-8
       User-Agent:
-      - pano-cli/1.2.0
+      - pano-cli/1.4.0
     method: POST
     uri: https://id.panoramichq.com/oauth2/auscsj124wDoFObOJ4x6/v1/token
   response:
@@ -2365,7 +1493,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 02 Nov 2020 15:12:12 GMT
+      - Fri, 20 Nov 2020 11:28:59 GMT
       Keep-Alive:
       - timeout=5, max=100
       Server:
@@ -2386,17 +1514,17 @@ interactions:
       - no-cache
       set-cookie:
       - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
-      - JSESSIONID=511A2FBCE3E8BA947E52CAABF4B97106; Path=/; Secure; HttpOnly
+      - JSESSIONID=2E52F37D30076C57CCEC5FDF23114CAA; Path=/; Secure; HttpOnly
       x-content-type-options:
       - nosniff
       x-okta-request-id:
-      - X6AhyytQvlZRW@@U2DoEZgAABoU
+      - X7eoe9VgTXUhOEc1@H@DwQAAASE
       x-rate-limit-limit:
       - '1200'
       x-rate-limit-remaining:
-      - '1194'
+      - '1176'
       x-rate-limit-reset:
-      - '1604329968'
+      - '1605871743'
       x-xss-protection:
       - '0'
     status:
@@ -2414,9 +1542,9 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - pano-cli/1.2.0
+      - pano-cli/1.4.0
     method: DELETE
-    uri: https://diesel.panoramicapi.com/api/v1/federated/model/test_model?virtual_data_source=test_dataset&company_slug=panoramic-z5y1clyi
+    uri: https://diesel.panoramicapi.com/api/v1/federated/model/test_model?virtual_data_source=test_dataset&company_slug=panoramic-cli-e2e-c2m6qp4u
   response:
     body:
       string: ''
@@ -2426,17 +1554,161 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Mon, 02 Nov 2020 15:12:12 GMT
+      - Fri, 20 Nov 2020 11:29:00 GMT
       Via:
       - kong/2.0.3
       X-Amzn-Trace-Id:
       - None
       X-Kong-Proxy-Latency:
-      - '1'
+      - '0'
       X-Kong-Upstream-Latency:
-      - '85'
+      - '40'
       x-diesel-request-id:
-      - abce10b3-8e44-45ff-9fb4-c3407a148119
+      - 9913f153-3903-4f8c-8bbd-7ea96b441b2f
+    status:
+      code: 204
+      message: NO CONTENT
+- request:
+    body: grant_type=client_credentials&scope=platform
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      User-Agent:
+      - pano-cli/1.4.0
+    method: POST
+    uri: https://id.panoramichq.com/oauth2/auscsj124wDoFObOJ4x6/v1/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": 3600, "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+        "scope": "platform"}'
+    headers:
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Fri, 20 Nov 2020 11:29:01 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      cache-control:
+      - no-cache, no-store
+      expires:
+      - '0'
+      p3p:
+      - CP="HONK"
+      pragma:
+      - no-cache
+      set-cookie:
+      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      - JSESSIONID=FF2EC554D2153F054DF7E37C01CE6026; Path=/; Secure; HttpOnly
+      x-content-type-options:
+      - nosniff
+      x-okta-request-id:
+      - X7eofIR6AG5cmLTbA4bDngAABZY
+      x-rate-limit-limit:
+      - '1200'
+      x-rate-limit-remaining:
+      - '1175'
+      x-rate-limit-reset:
+      - '1605871743'
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '["company_test_field"]'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '22'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - pano-cli/1.4.0
+    method: POST
+    uri: https://diesel.panoramicapi.com/api/v1/federated/taxonomy/taxons/delete?company_slug=panoramic-cli-e2e-c2m6qp4u
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Fri, 20 Nov 2020 11:29:01 GMT
+      Via:
+      - kong/2.0.3
+      X-Amzn-Trace-Id:
+      - None
+      X-Kong-Proxy-Latency:
+      - '0'
+      X-Kong-Upstream-Latency:
+      - '261'
+      x-diesel-request-id:
+      - e3969afb-0d6e-46f9-990a-b2b2b4461397
+    status:
+      code: 204
+      message: NO CONTENT
+- request:
+    body: '["test_dataset|dataset_test_field"]'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '35'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - pano-cli/1.4.0
+    method: POST
+    uri: https://diesel.panoramicapi.com/api/v1/federated/taxonomy/taxons/delete?company_slug=panoramic-cli-e2e-c2m6qp4u
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Fri, 20 Nov 2020 11:29:02 GMT
+      Via:
+      - kong/2.0.3
+      X-Amzn-Trace-Id:
+      - None
+      X-Kong-Proxy-Latency:
+      - '0'
+      X-Kong-Upstream-Latency:
+      - '282'
+      x-diesel-request-id:
+      - 72c3a152-e3ca-4f4f-a02f-e16489e7fc06
     status:
       code: 204
       message: NO CONTENT

--- a/panoramic/cli/test_connections_e2e.py
+++ b/panoramic/cli/test_connections_e2e.py
@@ -22,7 +22,9 @@ def test_connections_e2e(monkeypatch, tmpdir):
         [
             'connection',
             'create',
-            'my-connection', '--type', 'postgres',
+            'my-connection',
+            '--type',
+            'postgres',
             '--user',
             'my-user',
             '--host',
@@ -39,21 +41,21 @@ def test_connections_e2e(monkeypatch, tmpdir):
 
     assert result.exit_code == 0, result.output
     connections_json = {
-            'auth': {
-                'client_id': 'test-client-id',
-                'client_secret': 'test-client-secret',
+        'auth': {
+            'client_id': 'test-client-id',
+            'client_secret': 'test-client-secret',
+        },
+        'connections': {
+            'my-connection': {
+                'type': 'postgres',
+                'user': 'my-user',
+                'host': 'localhost',
+                'port': 5432,
+                'database': 'my_db',
+                'password': 'my-password',
             },
-            'connections': {
-                'my-connection': {
-                    'type': 'postgres',
-                    'user': 'my-user',
-                    'host': 'localhost',
-                    'port': 5432,
-                    'database': 'my_db',
-                    'password': 'my-password',
-                },
-            },
-        }
+        },
+    }
     with Paths.config_file().open() as f:
         assert yaml.safe_load(f.read()) == connections_json
 
@@ -63,8 +65,7 @@ def test_connections_e2e(monkeypatch, tmpdir):
     assert result.output == yaml.dump(connections_json['connections']) + "\n"
 
     # Update
-    result = runner.invoke(cli, ['connection', 'update', 'my-connection', '--database', 'my-new-db',
-                                 '--no-test'])
+    result = runner.invoke(cli, ['connection', 'update', 'my-connection', '--database', 'my-new-db', '--no-test'])
     assert result.exit_code == 0, result.output
 
     # List

--- a/panoramic/cli/test_push_pull_e2e.py
+++ b/panoramic/cli/test_push_pull_e2e.py
@@ -15,7 +15,7 @@ display_name: Test Dataset
 TEST_MODEL = """
 api_version: v1
 model_name: test_model
-data_source: pano_snowflake_66.snowflake_sample_data.tpch_sf1.nation
+data_source: pano_snowflake_panoramic_cli_e_2_e_c_2_m_6_qp_4_u.snowflake_sample_data.tpch_sf1.nation
 fields:
   - field_map:
       - dataset_test_field
@@ -27,19 +27,24 @@ joins:
     fields:
       - dataset_test_field
 identifiers:
-  - name
+  - dataset_test_field
 """
 
 TEST_COMPANY_FIELD = """
+aggregation:
+  type: group_by
 api_version: v1
 slug: company_test_field
 display_name: Company test field
 group: Custom
+calculation: 2 + 2
 field_type: dimension
 data_type: text
 """
 
 TEST_DATASET_FIELD = """
+aggregation:
+  type: sum
 api_version: v1
 slug: dataset_test_field
 display_name: Dataset test field

--- a/scenarios/pano-push-pull/pano.yaml
+++ b/scenarios/pano-push-pull/pano.yaml
@@ -1,2 +1,2 @@
 api_version: v1
-company_slug: panoramic-z5y1clyi
+company_slug: panoramic-cli-e2e-c2m6qp4u


### PR DESCRIPTION
Using data connection `pano_snowflake_panoramic_cli_e_2_e_c_2_m_6_qp_4_u` and company `panoramic-cli-e2e-c2m6qp4u` for testing - this avoids conflicts with any other datasets.

Before, we used company `panoramic-z5y1clyi` which contained some Hubspot data that was leaking into e2e test cassettes